### PR TITLE
Issue with decoding longs in argonaut support

### DIFF
--- a/support/argonaut/src/main/scala/Parser.scala
+++ b/support/argonaut/src/main/scala/Parser.scala
@@ -11,7 +11,7 @@ object Parser extends SupportParser[Json] {
       def jfalse() = Json.jFalse
       def jtrue() = Json.jTrue
       def jnum(s: String) = Json.jNumberOrNull(java.lang.Double.parseDouble(s))
-      def jint(s: String) = Json.jNumberOrNull(java.lang.Double.parseDouble(s))
+      def jint(s: String) = Json.jNumber(java.lang.Long.parseLong(s))
       def jstring(s: String) = Json.jString(s)
 
       def singleContext() = new FContext[Json] {

--- a/support/argonaut/src/test/scala/ParserSpec.scala
+++ b/support/argonaut/src/test/scala/ParserSpec.scala
@@ -1,0 +1,41 @@
+package jawn
+package support.argonaut
+
+import argonaut._
+import Argonaut._
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalatest.prop.Checkers
+import org.scalatest.{Matchers, FlatSpec}
+import scala.util.Try
+
+object ParserSpec {
+  case class Example(a: Int, b: Long, c: Double)
+
+  val exampleCodecJson: CodecJson[Example] =
+    casecodec3(Example.apply, Example.unapply)("a", "b", "c")
+
+  implicit val exampleCaseClassArbitrary: Arbitrary[Example] = Arbitrary(
+    for {
+      a <- arbitrary[Int]
+      b <- arbitrary[Long]
+      c <- arbitrary[Double]
+    } yield Example(a, b, c)
+  )
+}
+
+class ParserSpec extends FlatSpec with Matchers with Checkers {
+  import ParserSpec._
+  import jawn.support.argonaut.Parser.facade
+
+  "The Argonaut support Parser" should "correctly marshal case classes with Long values" in {
+    check { (e: Example) =>
+      val jsonString: String = exampleCodecJson.encode(e).nospaces
+      val json: Try[Json] = jawn.Parser.parseFromString(jsonString)
+      exampleCodecJson.decodeJson(json.get).toOption match {
+        case None => fail()
+        case Some(example) => example == e
+      }
+    }
+  }
+}


### PR DESCRIPTION
We've been discussing using Jawn as the Parser for Argonaut in [Finch](https://github.com/finagle/finch) and have run across an [issue](https://github.com/finagle/finch/issues/287) with decoding case classes that have Longs in them. We tracked it back to a precision issue with [how the Argonaut Facade handles](https://github.com/non/jawn/blob/master/support/argonaut/src/main/scala/Parser.scala#L14) `jint`. I've modified the `jint` method to use `Long.parseLong` instead of `Double.parseDouble` and I've included a a property test for it. If you keep the test case but use the implementation with `Double.parseDouble` you will get precision errors.

Let me know what you think and if you would like me to modify this PR in anyway to better fit the style of the repo. Thanks!