### PR TITLE
bump Play dependency to version 2.4.2

### DIFF
--- a/support/play/build.sbt
+++ b/support/play/build.sbt
@@ -1,7 +1,5 @@
 name := "play-support"
 
-resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
-
 libraryDependencies ++= Seq(
-  "com.typesafe.play" %% "play-json" % "2.3.6"
+  "com.typesafe.play" %% "play-json" % "2.4.2"
 )

--- a/support/play/src/main/scala/Parser.scala
+++ b/support/play/src/main/scala/Parser.scala
@@ -1,49 +1,19 @@
 package jawn
 package support.play
 
-import scala.collection.mutable
 import play.api.libs.json._
 
 object Parser extends SupportParser[JsValue] {
 
   implicit val facade: Facade[JsValue] =
-    new Facade[JsValue] {
+    new SimpleFacade[JsValue] {
       def jnull() = JsNull
       def jfalse() = JsBoolean(false)
       def jtrue() = JsBoolean(true)
       def jnum(s: String) = JsNumber(BigDecimal(s))
       def jint(s: String) = JsNumber(BigDecimal(s))
       def jstring(s: String) = JsString(s)
-
-      def singleContext() =
-        new FContext[JsValue] {
-          var value: JsValue = null
-          def add(s: String) { value = jstring(s) }
-          def add(v: JsValue) { value = v }
-          def finish: JsValue = value
-          def isObj: Boolean = false
-        }
-
-      def arrayContext() =
-        new FContext[JsValue] {
-          val vs = mutable.ListBuffer.empty[JsValue]
-          def add(s: String) { vs += jstring(s) }
-          def add(v: JsValue) { vs += v }
-          def finish: JsValue = JsArray(vs.toList)
-          def isObj: Boolean = false
-        }
-
-      def objectContext() =
-        new FContext[JsValue] {
-          var key: String = null
-          var vs = List.empty[(String, JsValue)]
-          def add(s: String): Unit =
-            if (key == null) key = s
-            else { vs = (key, jstring(s)) :: vs; key = null }
-          def add(v: JsValue): Unit =
-            { vs = (key, v) :: vs; key = null }
-          def finish: JsValue = JsObject(vs)
-          def isObj: Boolean = true
-        }
+      def jarray(vs: List[JsValue]) = JsArray(vs)
+      def jobject(vs: Map[String, JsValue]) = JsObject(vs)
     }
 }


### PR DESCRIPTION
Play 2.4 changed the constructor of `JsObject` to take a `Map` instead
of `Seq`, losing binary compatibility.  Play 2.3 will require an older
version of `jawn-play` without this change.

Resolves #41 