### PR TITLE
Fix CharBuilder#extend

### DIFF
--- a/parser/src/main/scala/jawn/CharBuilder.scala
+++ b/parser/src/main/scala/jawn/CharBuilder.scala
@@ -39,6 +39,7 @@ private[jawn] final class CharBuilder {
     resizeIfNecessary(tlen)
     var i = 0
     var j = len
+    len = tlen
     while (i < s.length) { cs(j) = s.charAt(i); i += 1; j += 1 }
   }
 

--- a/parser/src/test/scala/jawn/CharBuilderSpec.scala
+++ b/parser/src/test/scala/jawn/CharBuilderSpec.scala
@@ -1,0 +1,25 @@
+package jawn
+
+import org.scalactic.TypeCheckedTripleEquals
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.PropSpec
+
+class CharBuilderSpec extends PropSpec with TypeCheckedTripleEquals with GeneratorDrivenPropertyChecks {
+
+  property("append") {
+    forAll { xs: List[Char] =>
+      val builder = new CharBuilder
+      xs.foreach(builder.append)
+      assert(builder.makeString === xs.mkString)
+    }
+  }
+
+  property("extend") {
+    forAll { xs: List[String] =>
+      val builder = new CharBuilder
+      xs.foreach(builder.extend)
+      assert(builder.makeString === xs.mkString)
+    }
+  }
+
+}


### PR DESCRIPTION
`CharBuilder#extend` did not update `len`. This is intended to fix #45.