### PR TITLE
Support very large strings

### DIFF
--- a/ast/src/test/scala/jawn/ParseCheck.scala
+++ b/ast/src/test/scala/jawn/ParseCheck.scala
@@ -33,6 +33,10 @@ class AstCheck extends PropSpec with Matchers with GeneratorDrivenPropertyChecks
 
       value1 shouldBe value2
       value1.## shouldBe value2.##
+
+      parser.Util.withTemp(json1) { t =>
+        JParser.parseFromFile(t).get shouldBe value2
+      }
     }
   }
 
@@ -101,9 +105,7 @@ class AstCheck extends PropSpec with Matchers with GeneratorDrivenPropertyChecks
 
   property("if x == y, then x.## == y.##") {
     forAll { (x: JValue, y: JValue) =>
-      if (x == y) {
-        x.## shouldBe y.##
-      }
+      if (x == y) x.## shouldBe y.##
     }
   }
 
@@ -124,6 +126,23 @@ class AstCheck extends PropSpec with Matchers with GeneratorDrivenPropertyChecks
       check(DeferNum(s + ".000"))
       check(DeferNum(s + "e0"))
       check(DeferNum(s + ".0e0"))
+    }
+  }
+
+  property("large strings") {
+    val M = 1000000
+    val q = "\""
+
+    val s0 = ("x" * (40 * M))
+    val e0 = q + s0 + q
+    parser.Util.withTemp(e0) { t =>
+      JParser.parseFromFile(t).filter(_ == JString(s0)).isSuccess shouldBe true
+    }
+
+    val s1 = "\\" * (20 * M)
+    val e1 = q + s1 + s1 + q
+    parser.Util.withTemp(e1) { t =>
+      JParser.parseFromFile(t).filter(_ == JString(s1)).isSuccess shouldBe true
     }
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -82,7 +82,7 @@ lazy val parser = project.in(file("parser"))
   .settings(jawnSettings: _*)
 
 lazy val ast = project.in(file("ast"))
-  .dependsOn(parser)
+  .dependsOn(parser % "compile->compile;test->test")
   .disablePlugins(JmhPlugin)
   .settings(name := "ast")
   .settings(moduleName := "jawn-ast")

--- a/parser/src/main/scala/jawn/AsyncParser.scala
+++ b/parser/src/main/scala/jawn/AsyncParser.scala
@@ -121,16 +121,16 @@ final class AsyncParser[J] protected[jawn] (
    * ASYNC_PRESTART: We haven't seen any non-whitespace yet. We
    * could be parsing an array, or not. We are waiting for valid
    * JSON.
-   * 
+   *
    * ASYNC_START: We've seen an array and have begun unwrapping
    * it. We could see a ] if the array is empty, or valid JSON.
-   * 
+   *
    * ASYNC_END: We've parsed an array and seen the final ]. At this
    * point we should only see whitespace or an EOF.
-   * 
+   *
    * ASYNC_POSTVAL: We just parsed a value from inside the array. We
-   * expect to see whitespace, a comma, or an EOF.
-   * 
+   * expect to see whitespace, a comma, or a ].
+   *
    * ASYNC_PREVAL: We are in an array and we just saw a comma. We
    * expect to see whitespace or a JSON value.
    */
@@ -275,16 +275,12 @@ final class AsyncParser[J] protected[jawn] (
    * This is a specialized accessor for the case where our underlying data are
    * bytes not chars.
    */
-  protected[this] final def byte(i: Int): Byte = if (i >= len)
-    throw new AsyncException
-  else
-    data(i)
+  protected[this] final def byte(i: Int): Byte =
+    if (i >= len) throw new AsyncException else data(i)
 
   // we need to signal if we got out-of-bounds
-  protected[this] final def at(i: Int): Char = if (i >= len)
-    throw new AsyncException
-  else
-    data(i).toChar
+  protected[this] final def at(i: Int): Char =
+    if (i >= len) throw new AsyncException else data(i).toChar
 
   /**
    * Access a byte range as a string.
@@ -303,10 +299,11 @@ final class AsyncParser[J] protected[jawn] (
 
   // the basic idea is that we don't signal EOF until done is true, which means
   // the client explicitly send us an EOF.
-  protected[this] final def atEof(i: Int) = if (done) i >= len else false
+  protected[this] final def atEof(i: Int): Boolean =
+    if (done) i >= len else false
 
   // we don't have to do anything special on close.
-  protected[this] final def close() = ()
+  protected[this] final def close(): Unit = ()
 }
 
 /**

--- a/parser/src/main/scala/jawn/ByteBasedParser.scala
+++ b/parser/src/main/scala/jawn/ByteBasedParser.scala
@@ -29,7 +29,7 @@ trait ByteBasedParser[J] extends Parser[J] {
     var j = i
     var c: Int = byte(j) & 0xff
     while (c != 34) {
-      if (c < 32) return die(j, s"control char ($c) in string" format c)
+      if (c < 32) return die(j, s"control char ($c) in string")
       if (c == 92) return -1
       j += 1
       c = byte(j) & 0xff

--- a/parser/src/main/scala/jawn/ChannelParser.scala
+++ b/parser/src/main/scala/jawn/ChannelParser.scala
@@ -102,7 +102,7 @@ final class ChannelParser[J](ch: ReadableByteChannel, bufferSize: Int) extends S
    * current byte buffer, do a swap, load some more data, and
    * continue.
    */
-  protected[this] final def reset(i: Int): Int = {
+  protected[this] final def reset(i: Int): Int =
     if (i >= Bufsize) {
       swap()
       nnext = ch.read(ByteBuffer.wrap(next))
@@ -111,7 +111,6 @@ final class ChannelParser[J](ch: ReadableByteChannel, bufferSize: Int) extends S
     } else {
       i
     }
-  }
 
   protected[this] final def checkpoint(state: Int, i: Int, stack: List[FContext[J]]): Unit = ()
 
@@ -143,7 +142,6 @@ final class ChannelParser[J](ch: ReadableByteChannel, bufferSize: Int) extends S
    */
   protected[this] final def at(i: Int, k: Int): String = {
     val len = k - i
-
     if (k > Allsize) {
       grow()
       at(i, k)
@@ -161,5 +159,6 @@ final class ChannelParser[J](ch: ReadableByteChannel, bufferSize: Int) extends S
   }
 
   protected[this] final def atEof(i: Int) =
-    if (i < Bufsize) i >= ncurr else (i - Bufsize) >= nnext
+    if (i < Bufsize) i >= ncurr
+    else i >= (nnext + Bufsize)
 }

--- a/parser/src/main/scala/jawn/Parser.scala
+++ b/parser/src/main/scala/jawn/Parser.scala
@@ -112,7 +112,7 @@ abstract class Parser[J] {
   /**
    * Used to generate error messages with character info and offsets.
    */
-  protected[this] def die(i: Int, msg: String) = {
+  protected[this] def die(i: Int, msg: String): Nothing = {
     val y = line() + 1
     val x = column(i) + 1
     val s = "%s got %s (line %d, column %d)" format (msg, at(i), y, x)
@@ -292,7 +292,7 @@ abstract class Parser[J] {
     var i = 0
     var x = 0
     while (i < 4) {
-      x = (x << 4) | hc(s.charAt(i))
+      x = (x << 4) | hc(s.charAt(i).toInt)
       i += 1
     }
     x.toChar

--- a/parser/src/test/scala/jawn/ChannelSpec.scala
+++ b/parser/src/test/scala/jawn/ChannelSpec.scala
@@ -1,0 +1,25 @@
+package jawn
+package parser
+
+import org.scalatest._
+
+import java.nio.channels.ByteChannel
+import scala.util.Success
+
+class ChannelSpec extends PropSpec with Matchers {
+
+  property("large strings in files are ok") {
+    val M = 1000000
+    val q = "\""
+    val big = q + ("x" * (40 * M)) + q
+    val bigEscaped = q + ("\\\\" * (20 * M)) + q
+
+    Util.withTemp(big) { t =>
+      Parser.parseFromFile(t)(NullFacade).isSuccess shouldBe true
+    }
+
+    Util.withTemp(bigEscaped) { t =>
+      Parser.parseFromFile(t)(NullFacade).isSuccess shouldBe true
+    }
+  }
+}

--- a/parser/src/test/scala/jawn/SyntaxCheck.scala
+++ b/parser/src/test/scala/jawn/SyntaxCheck.scala
@@ -1,7 +1,6 @@
 package jawn
 package parser
 
-import org.scalatest.matchers.ShouldMatchers
 import org.scalatest._
 import prop._
 import org.scalacheck.Arbitrary._
@@ -67,6 +66,10 @@ class SyntaxCheck extends PropSpec with Matchers with GeneratorDrivenPropertyChe
     val bb = ByteBuffer.wrap(s.getBytes("UTF-8"))
     val r2 = Parser.parseFromByteBuffer(bb)(NullFacade).isSuccess
     if (r1 == r2) r1 else sys.error(s"String/ByteBuffer parsing disagree($r1, $r2): $s")
+
+    Util.withTemp(s) { t =>
+      Parser.parseFromFile(t)(NullFacade).isSuccess
+    }
 
     val async = AsyncParser[Unit](AsyncParser.SingleValue)
     val r3 = async.absorb(s)(NullFacade).isRight && async.finish()(NullFacade).isRight

--- a/parser/src/test/scala/jawn/Util.scala
+++ b/parser/src/test/scala/jawn/Util.scala
@@ -1,0 +1,18 @@
+package jawn
+package parser
+
+import java.io._
+
+object Util {
+  def withTemp[A](s: String)(f: File => A): A = {
+    val t = File.createTempFile("jawn-syntax", ".json")
+    val pw = new PrintWriter(t)
+    pw.println(s)
+    pw.close()
+    try {
+      f(t)
+    } finally {
+      t.delete()
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the ability to parse really big strings. Previously, valid strings larger than 1-2M would fail to parse. After this PR, it will definitely be able to handle at least 1G strings.

I think this is a good change, although in general the presence of very large strings in JSON is often a sign that something went wrong. I thought about making the support optional but that seems like too many levers. I'm also open to closing this PR if overall people prefer the fail fast behavior.

What do you all think? I'd like to do a new Jawn release soon (there are some other small changes too).

/cc @easel @travisbrown