### PR TITLE
sbt-doge and sbt-release integration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,6 @@ lazy val jawnSettings = Seq(
 
   // release stuff
   releaseCrossBuild := true,
-  releasePublishArtifactsAction := PgpKeys.publishSigned.value,
   publishMavenStyle := true,
   publishArtifact in Test := false,
   pomIncludeRepository := Function.const(false),
@@ -57,7 +56,7 @@ lazy val jawnSettings = Seq(
     setReleaseVersion,
     commitReleaseVersion,
     tagRelease,
-    publishArtifacts,
+    ReleaseHelper.runCommandAndRemaining("+publishSigned"),
     setNextVersion,
     commitNextVersion,
     ReleaseStep(action = Command.process("sonatypeReleaseAll", _)),
@@ -70,6 +69,7 @@ lazy val noPublish = Seq(
 
 lazy val root = project.in(file("."))
   .aggregate(all.map(Project.projectToRef): _*)
+  .enablePlugins(CrossPerProjectPlugin)
   .disablePlugins(JmhPlugin)
   .settings(name := "jawn")
   .settings(jawnSettings: _*)

--- a/project/ReleaseHelper.scala
+++ b/project/ReleaseHelper.scala
@@ -1,0 +1,34 @@
+import sbt._
+import sbt.Keys._
+import sbt.complete.Parser
+
+object ReleaseHelper {
+
+  /** Invoke a command and carry out remaining commands until completion.
+    *
+    * This is necessary because sbt-release's releaseStepCommand does not
+    * execute remaining commands, which sbt-doge relies on.
+    *
+    * Based on https://github.com/playframework/playframework/blob/master/framework/project/Release.scala
+    *
+    * NOTE: This can be removed in favor of https://github.com/sbt/sbt-release/pull/171 if/when merged upstream
+    */
+  def runCommandAndRemaining(command: String): State => State = { originalState =>
+    val originalRemaining = originalState.remainingCommands
+
+    @annotation.tailrec
+    def runCommand(command: String, state: State): State = {
+      val newState = Parser.parse(command, state.combinedParser) match {
+        case Right(cmd) => cmd()
+        case Left(msg) => throw sys.error(s"Invalid programmatic input:\n$msg")
+      }
+      if (newState.remainingCommands.isEmpty) {
+        newState
+      } else {
+        runCommand(newState.remainingCommands.head, newState.copy(remainingCommands = newState.remainingCommands.tail))
+      }
+    }
+
+    runCommand(command, originalState.copy(remainingCommands = Nil)).copy(remainingCommands = originalRemaining)
+  }
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
+addSbtPlugin("com.eed3si9n"      % "sbt-doge"     % "0.1.5")
 addSbtPlugin("com.jsuereth"      % "sbt-pgp"      % "1.0.0")
 addSbtPlugin("com.github.gseitz" % "sbt-release"  % "1.0.0")
 addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype" % "0.5.0")


### PR DESCRIPTION
- add sbt-doge plugin
- utility function for fixing command invocation during ReleaseStep

Attempts to fix #57.

Using the solution that you linked to in [playframework](https://github.com/playframework/playframework/blob/master/framework/project/Release.scala) worked for us at Tapad, so I applied to same logic here. My limited testing (just publishing the signed artifact to my local Maven repo) showed that the release process worked as I would expect when sbt-doge was added.

I didn't follow up with @dwijnand's solution as the one from play worked for us.