### PR TITLE
Set up cross-builds and 2.12.0-RC1.

### DIFF
--- a/ast/build.sbt
+++ b/ast/build.sbt
@@ -1,1 +1,0 @@
-name := "jawn-ast"

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import ReleaseTransformations._
 lazy val jawnSettings = Seq(
   organization := "org.spire-math",
   scalaVersion := "2.11.8",
-  crossScalaVersions := Seq("2.10.6", "2.11.8"),
+  crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.0-RC1"),
 
   resolvers += Resolver.sonatypeRepo("releases"),
   libraryDependencies ++= Seq(
@@ -11,7 +11,7 @@ lazy val jawnSettings = Seq(
     "org.scalacheck" %% "scalacheck" % "1.13.2" % "test"
   ),
   scalacOptions ++= Seq(
-    "-Yinline-warnings",
+    //"-Yinline-warnings",
     "-deprecation",
     "-optimize",
     "-unchecked"
@@ -76,39 +76,51 @@ lazy val root = project.in(file("."))
   .settings(noPublish: _*)
 
 lazy val parser = project.in(file("parser"))
-  .disablePlugins(JmhPlugin)
   .settings(name := "parser")
   .settings(moduleName := "jawn-parser")
   .settings(jawnSettings: _*)
+  .disablePlugins(JmhPlugin)
 
 lazy val ast = project.in(file("ast"))
   .dependsOn(parser % "compile->compile;test->test")
-  .disablePlugins(JmhPlugin)
   .settings(name := "ast")
   .settings(moduleName := "jawn-ast")
   .settings(jawnSettings: _*)
+  .disablePlugins(JmhPlugin)
 
 def support(name: String) =
   Project(id = name, base = file(s"support/$name"))
     .dependsOn(parser)
-    .disablePlugins(JmhPlugin)
     .settings(moduleName := "jawn-" + name)
     .settings(jawnSettings: _*)
+    .disablePlugins(JmhPlugin)
 
 lazy val supportArgonaut = support("argonaut")
+  .settings(crossScalaVersions := Seq("2.10.6", "2.11.8"))
+
 lazy val supportJson4s = support("json4s")
+  .settings(crossScalaVersions := Seq("2.10.6", "2.11.8"))
+
 lazy val supportPlay = support("play")
+  .settings(crossScalaVersions := Seq("2.11.8"))
+
 lazy val supportRojoma = support("rojoma")
+  .settings(crossScalaVersions := Seq("2.10.6", "2.11.8"))
+
 lazy val supportRojomaV3 = support("rojoma-v3")
+  .settings(crossScalaVersions := Seq("2.10.6", "2.11.8"))
+
 lazy val supportSpray = support("spray")
+  .settings(crossScalaVersions := Seq("2.10.6", "2.11.8"))
 
 lazy val benchmark = project.in(file("benchmark"))
   .dependsOn(all.map(Project.classpathDependency[Project]): _*)
-  .enablePlugins(JmhPlugin)
   .settings(name := "jawn-benchmark")
   .settings(jawnSettings: _*)
   .settings(scalaVersion := "2.11.8")
   .settings(noPublish: _*)
+  .settings(crossScalaVersions := Seq("2.11.8"))
+  .enablePlugins(JmhPlugin)
 
 lazy val all =
   Seq(parser, ast, supportArgonaut, supportJson4s, supportPlay, supportRojoma, supportRojomaV3, supportSpray)

--- a/parser/build.sbt
+++ b/parser/build.sbt
@@ -1,1 +1,0 @@
-name := "jawn-parser"

--- a/support/play/build.sbt
+++ b/support/play/build.sbt
@@ -1,5 +1,5 @@
 name := "play-support"
 
 libraryDependencies ++= Seq(
-  "com.typesafe.play" %% "play-json" % "2.4.2"
+  "com.typesafe.play" %% "play-json" % "2.5.8"
 )

--- a/support/rojoma-v3/build.sbt
+++ b/support/rojoma-v3/build.sbt
@@ -1,5 +1,5 @@
 name := "rojoma-v3-support"
 
 libraryDependencies ++= Seq(
-  "com.rojoma" %% "rojoma-json-v3" % "3.2.1"
+  "com.rojoma" %% "rojoma-json-v3" % "3.3.0"
 )


### PR DESCRIPTION
This commit prepares for a new release.

The main difference is that we can only publish the *play support* for 2.11, and none of the other support modules can handle 2.12 yet. Thanks to #58 we can hopefully still publish the *parser* and *ast* submodules for 2.12.

(However, see the comments in #58 for status on the current release.)

/cc @dwijnand @jeffreyolchovy 