### PR TITLE
Cross build for Scala 2.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,15 +133,14 @@ arbitrary data type (provided you also have an implicit `Facade[J]`).
 
 Jawn currently supports six external ASTs directly:
 
- * Argonaut (6.1)
- * **Json4s (3.3.0)**
- * *Play (2.5.8)*
- * Rojoma (2.4.3)
- * Rojoma-v3 (3.3.0)
- * **Spray (1.3.1)**
-
-(Projects in **bold** support Scala 2.10, 2.11, and 2.12.0-RC1.
-Projects in *italics* support only Scala 2.11.)
+| AST       | 2.10  | 2.11  | 2.12  |
+|-----------|-------|-------|-------|
+| Argonaut  | 6.1   | 6.1   |       |
+| Json4s    | 3.4.2 | 3.4.2 | 3.4.2 |
+| Play      |       | 2.5.8 |       |
+| Rojoma    | 2.4.3 | 2.4.3 |       |
+| Rojoma-v3 | 3.3.0 | 3.3.0 |       |
+| Spray     | 1.3.2 | 1.3.2 | 1.3.2 |
 
 Each of these subprojects provides a `Parser` object (an instance of
 `SupportParser[J]`) that is parameterized on the given project's

--- a/build.sbt
+++ b/build.sbt
@@ -3,12 +3,12 @@ import ReleaseTransformations._
 lazy val jawnSettings = Seq(
   organization := "org.spire-math",
   scalaVersion := "2.11.8",
-  crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.0-RC2"),
+  crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.0"),
 
   resolvers += Resolver.sonatypeRepo("releases"),
   libraryDependencies ++= Seq(
     "org.scalatest" %% "scalatest" % "3.0.0" % "test",
-    "org.scalacheck" %% "scalacheck" % "1.13.2" % "test"
+    "org.scalacheck" %% "scalacheck" % "1.13.4" % "test"
   ),
   scalacOptions ++= Seq(
     //"-Yinline-warnings",

--- a/support/json4s/build.sbt
+++ b/support/json4s/build.sbt
@@ -1,5 +1,5 @@
 name := "json4s-support"
 
 libraryDependencies ++= Seq(
-  "org.json4s" %% "json4s-ast" % "3.4.1"
+  "org.json4s" %% "json4s-ast" % "3.4.2"
 )


### PR DESCRIPTION
Upgrades json4s to 3.4 to get the necessary triple cross-build.