### PR TITLE
Don't define charBuilder where it's unneeded

### DIFF
--- a/parser/src/main/scala/jawn/CharBasedParser.scala
+++ b/parser/src/main/scala/jawn/CharBasedParser.scala
@@ -13,6 +13,8 @@ import scala.annotation.{switch, tailrec}
  */
 private[jawn] trait CharBasedParser[J] extends Parser[J] {
 
+  private[this] final val charBuilder = new CharBuilder()
+
   /**
    * See if the string has any escape sequences. If not, return the
    * end of the string. If so, bail out and return -1.

--- a/parser/src/main/scala/jawn/Parser.scala
+++ b/parser/src/main/scala/jawn/Parser.scala
@@ -35,8 +35,6 @@ abstract class Parser[J] {
 
   protected[this] final val utf8 = Charset.forName("UTF-8")
 
-  protected[this] final val charBuilder = new CharBuilder()
-
   /**
    * Read the byte/char at 'i' as a Char.
    *


### PR DESCRIPTION
This is a minor change, but since we only use `charBuilder` in `CharBasedParser` I just moved it to there and locked down its access.