### PR TITLE
Remove methods from ByteBufferParser's public API

### DIFF
--- a/parser/src/main/scala/jawn/ByteBufferParser.scala
+++ b/parser/src/main/scala/jawn/ByteBufferParser.scala
@@ -14,11 +14,13 @@ import java.nio.ByteBuffer
  * update its own mutable position fields.
  */
 final class ByteBufferParser[J](src: ByteBuffer) extends SyncParser[J] with ByteBasedParser[J] {
-  final val start = src.position
-  final val limit = src.limit - start
+  private[this] final val start = src.position
+  private[this] final val limit = src.limit - start
 
-  var line = 0
-  protected[this] final def newline(i: Int) { line += 1 }
+  private[this] var lineState = 0
+  protected[this] def line(): Int = lineState
+
+  protected[this] final def newline(i: Int) { lineState += 1 }
   protected[this] final def column(i: Int) = i
 
   protected[this] final def close() { src.position(src.limit) }


### PR DESCRIPTION
Another minor change—there's not really any reason for anyone outside to modify `ByteBufferParser`'s `line`, and nobody else should need to see its position / limit state.