### PR TITLE
Add indices to jnum, remove jint

### DIFF
--- a/ast/src/main/scala/jawn/ast/JawnFacade.scala
+++ b/ast/src/main/scala/jawn/ast/JawnFacade.scala
@@ -8,8 +8,12 @@ object JawnFacade extends Facade[JValue] {
   final val jnull = JNull
   final val jfalse = JFalse
   final val jtrue = JTrue
-  final def jnum(s: String) = DeferNum(s)
-  final def jint(s: String) = DeferLong(s)
+  final def jnum(s: String, decIndex: Int, expIndex: Int) =
+    if (decIndex == -1 && expIndex == -1) {
+      DeferLong(s)
+    } else {
+      DeferNum(s)
+    }
   final def jstring(s: String) = JString(s)
 
   final def singleContext(): FContext[JValue] =

--- a/parser/src/main/scala/jawn/Facade.scala
+++ b/parser/src/main/scala/jawn/Facade.scala
@@ -15,8 +15,7 @@ trait Facade[J] {
   def jnull(): J
   def jfalse(): J
   def jtrue(): J
-  def jnum(s: String): J
-  def jint(s: String): J
+  def jnum(s: String, decIndex: Int, expIndex: Int): J
   def jstring(s: String): J
 }
 

--- a/parser/src/main/scala/jawn/NullFacade.scala
+++ b/parser/src/main/scala/jawn/NullFacade.scala
@@ -25,7 +25,6 @@ object NullFacade extends Facade[Unit] {
   def jnull(): Unit = ()
   def jfalse(): Unit = ()
   def jtrue(): Unit = ()
-  def jnum(s: String): Unit = ()
-  def jint(s: String): Unit = ()
+  def jnum(s: String, decIndex: Int, expIndex: Int): Unit = ()
   def jstring(s: String): Unit = ()
 }

--- a/parser/src/main/scala/jawn/Parser.scala
+++ b/parser/src/main/scala/jawn/Parser.scala
@@ -146,7 +146,7 @@ abstract class Parser[J] {
     }
 
     if (c == '.') {
-      decIndex = j
+      decIndex = j - i
       j += 1
       c = at(j)
       if ('0' <= c && c <= '9') {
@@ -157,7 +157,7 @@ abstract class Parser[J] {
     }
 
     if (c == 'e' || c == 'E') {
-      expIndex = j
+      expIndex = j - i
       j += 1
       c = at(j)
       if (c == '+' || c == '-') {
@@ -222,7 +222,7 @@ abstract class Parser[J] {
 
     if (c == '.') {
       // any valid input will require at least one digit after .
-      decIndex = j
+      decIndex = j - i
       j += 1
       c = at(j)
       if ('0' <= c && c <= '9') {
@@ -241,7 +241,7 @@ abstract class Parser[J] {
 
     if (c == 'e' || c == 'E') {
       // any valid input will require at least one digit after e, e+, etc
-      expIndex = j
+      expIndex = j - i
       j += 1
       c = at(j)
       if (c == '+' || c == '-') {

--- a/support/argonaut/src/main/scala/Parser.scala
+++ b/support/argonaut/src/main/scala/Parser.scala
@@ -10,8 +10,8 @@ object Parser extends SupportParser[Json] {
       def jnull() = Json.jNull
       def jfalse() = Json.jFalse
       def jtrue() = Json.jTrue
-      def jnum(s: String) = Json.jNumber(JsonNumber.unsafeDecimal(s))
-      def jint(s: String) = Json.jNumber(JsonNumber.unsafeDecimal(s))
+      def jnum(s: String, decIndex: Int, expIndex: Int) =
+        Json.jNumber(JsonNumber.unsafeDecimal(s))
       def jstring(s: String) = Json.jString(s)
 
       def singleContext() = new FContext[Json] {

--- a/support/json4s/src/main/scala/Parser.scala
+++ b/support/json4s/src/main/scala/Parser.scala
@@ -13,8 +13,15 @@ class Parser(useBigDecimalForDouble: Boolean, useBigIntForLong: Boolean) extends
       def jnull() = JNull
       def jfalse() = JBool(false)
       def jtrue() = JBool(true)
-      def jnum(s: String) = if (useBigDecimalForDouble) JDecimal(BigDecimal(s)) else JDouble(s.toDouble)
-      def jint(s: String) = if (useBigIntForLong) JInt(BigInt(s)) else JLong(s.toLong)
+      def jnum(s: String, decIndex: Int, expIndex: Int) =
+        if (decIndex == -1 && expIndex == -1) {
+          if (useBigIntForLong) JInt(BigInt(s))
+          else JLong(s.toLong)
+        } else {
+          if (useBigDecimalForDouble) JDecimal(BigDecimal(s))
+          else JDouble(s.toDouble)
+        }
+
       def jstring(s: String) = JString(s)
 
       def singleContext() =

--- a/support/play/src/main/scala/Parser.scala
+++ b/support/play/src/main/scala/Parser.scala
@@ -10,8 +10,7 @@ object Parser extends SupportParser[JsValue] {
       def jnull() = JsNull
       def jfalse() = JsBoolean(false)
       def jtrue() = JsBoolean(true)
-      def jnum(s: String) = JsNumber(BigDecimal(s))
-      def jint(s: String) = JsNumber(BigDecimal(s))
+      def jnum(s: String, decIndex: Int, expIndex: Int) = JsNumber(BigDecimal(s))
       def jstring(s: String) = JsString(s)
       def jarray(vs: List[JsValue]) = JsArray(vs)
       def jobject(vs: Map[String, JsValue]) = JsObject(vs)

--- a/support/rojoma-v3/src/main/scala/Parser.scala
+++ b/support/rojoma-v3/src/main/scala/Parser.scala
@@ -10,8 +10,7 @@ object Parser extends SupportParser[JValue] {
       def jnull() = JNull
       def jfalse() = JBoolean.canonicalFalse
       def jtrue() = JBoolean.canonicalTrue
-      def jnum(s: String) = JNumber.unsafeFromString(s)
-      def jint(s: String) = JNumber.unsafeFromString(s)
+      def jnum(s: String, decIndex: Int, expIndex: Int) = JNumber.unsafeFromString(s)
       def jstring(s: String) = JString(s)
       def jarray(vs: mutable.ArrayBuffer[JValue]) = JArray(vs)
       def jobject(vs: mutable.Map[String, JValue]) = JObject(vs)

--- a/support/rojoma/src/main/scala/Parser.scala
+++ b/support/rojoma/src/main/scala/Parser.scala
@@ -10,8 +10,7 @@ object Parser extends SupportParser[JValue] {
       def jnull() = JNull
       def jfalse() = JBoolean.canonicalFalse
       def jtrue() = JBoolean.canonicalTrue
-      def jnum(s: String) = JNumber(BigDecimal(s))
-      def jint(s: String) = JNumber(BigDecimal(s))
+      def jnum(s: String, decIndex: Int, expIndex: Int) = JNumber(BigDecimal(s))
       def jstring(s: String) = JString(s)
       def jarray(vs: mutable.ArrayBuffer[JValue]) = JArray(vs)
       def jobject(vs: mutable.Map[String, JValue]) = JObject(vs)

--- a/support/spray/src/main/scala/Parser.scala
+++ b/support/spray/src/main/scala/Parser.scala
@@ -9,8 +9,7 @@ object Parser extends SupportParser[JsValue] {
       def jnull() = JsNull
       def jfalse() = JsFalse
       def jtrue() = JsTrue
-      def jnum(s: String) = JsNumber(s)
-      def jint(s: String) = JsNumber(s)
+      def jnum(s: String, decIndex: Int, expIndex: Int) = JsNumber(s)
       def jstring(s: String) = JsString(s)
       def jarray(vs: List[JsValue]) = JsArray(vs: _*)
       def jobject(vs: Map[String, JsValue]) = JsObject(vs)


### PR DESCRIPTION
The idea here is that the parser is already noting when it sees a decimal point or `e` in a JSON number so that it can know whether to call `jnum` or `jint`, and it could just as easily record their indices and pass those through to the facade via `jnum` (I've removed `jint` since it's redundant).

For libraries that do additional number parsing it can be useful to have these indices. I tried this out in circe, and for large numbers (80 digits here) the difference can be pretty big:

```
Benchmark                                    Mode  Cnt         Score        Error  Units
NumberParsingBenchmark.parse                thrpt   40  12113615.745 ± 178068.584  ops/s
NumberParsingBenchmark.parseWithoutIndices  thrpt   40   7439011.001 ±  99308.166  ops/s
```

(For smaller numbers there's less of an improvement—around 15% more throughput for a dozen digits).

Libraries that just call `BigDecimal(s)` or whatever in both cases have things a little easier, since they only need to provide one implementation, and libraries that do want to make a distinction can check whether both indices are `-1` to get the same thing as the `jint` case.

What do you think?
