### PR TITLE
Parser performance improvements

### DIFF
--- a/benchmark/src/main/scala/jawn/JmhBenchmarks.scala
+++ b/benchmark/src/main/scala/jawn/JmhBenchmarks.scala
@@ -10,7 +10,6 @@ import scala.collection.mutable
 @BenchmarkMode(Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 abstract class JmhBenchmarks(name: String) {
-
   val path: String = s"src/main/resources/$name"
 
   def load(path: String): String = {
@@ -27,6 +26,20 @@ abstract class JmhBenchmarks(name: String) {
   def buffered(path: String): BufferedReader =
     new BufferedReader(new FileReader(new File(path)))
 
+  @Benchmark
+  def jawnCheckSyntax() =
+    jawn.Syntax.checkString(load(path))
+
+  @Benchmark
+  def jawnParse() =
+    jawn.ast.JParser.parseFromFile(new File(path)).get
+
+  @Benchmark
+  def jawnStringParse() =
+    jawn.ast.JParser.parseFromString(load(path)).get
+}
+
+trait OtherBenchmarks { self: JmhBenchmarks =>
   @Benchmark
   def json4sJacksonParse() = {
     import org.json4s._
@@ -65,18 +78,6 @@ abstract class JmhBenchmarks(name: String) {
   def gsonParse() =
     new com.google.gson.JsonParser().parse(buffered(path))
 
-  @Benchmark
-  def jawnCheckSyntax() =
-    jawn.Syntax.checkString(load(path))
-
-  @Benchmark
-  def jawnParse() =
-    jawn.ast.JParser.parseFromFile(new File(path)).get
-
-  @Benchmark
-  def jawnStringParse() =
-    jawn.ast.JParser.parseFromString(load(path)).get
-
   // don't bother benchmarking jawn + external asts by default
 
   // @Benchmark
@@ -105,10 +106,15 @@ abstract class JmhBenchmarks(name: String) {
   // }
 }
 
-class Qux2Bench extends JmhBenchmarks("qux2.json")
-class Bla25Bench extends JmhBenchmarks("bla25.json")
-class CountriesBench extends JmhBenchmarks("countries.geo.json")
-class Ugh10kBench extends JmhBenchmarks("ugh10k.json")
+class Qux2Bench extends JmhBenchmarks("qux2.json") with OtherBenchmarks
+class Bla25Bench extends JmhBenchmarks("bla25.json") with OtherBenchmarks
+class CountriesBench extends JmhBenchmarks("countries.geo.json") with OtherBenchmarks
+class Ugh10kBench extends JmhBenchmarks("ugh10k.json") with OtherBenchmarks
+
+class JawnOnlyQux2Bench extends JmhBenchmarks("qux2.json")
+class JawnOnlyBla25Bench extends JmhBenchmarks("bla25.json")
+class JawnOnlyCountriesBench extends JmhBenchmarks("countries.geo.json")
+class JawnOnlyUgh10kBench extends JmhBenchmarks("ugh10k.json")
 
 // // from https://github.com/zemirco/sf-city-lots-json
 // class CityLotsBench extends JmhBenchmarks("citylots.json")

--- a/parser/src/main/scala/jawn/Parser.scala
+++ b/parser/src/main/scala/jawn/Parser.scala
@@ -386,188 +386,97 @@ abstract class Parser[J] {
   protected[this] final def rparse(state: Int, j: Int, stack: List[FContext[J]])(implicit facade: Facade[J]): (J, Int) = {
     val i = reset(j)
     checkpoint(state, i, stack)
-    (state: @switch) match {
+
+    val c = at(i)
+
+    if (c == '\n') {
+      newline(i)
+      rparse(state, i + 1, stack)
+    } else if (c == ' ' || c == '\t' || c == '\r') {
+      rparse(state, i + 1, stack)
+    } else if (state == DATA) {
       // we are inside an object or array expecting to see data
-      case DATA =>
-        (at(i): @switch) match {
-          case '[' => rparse(ARRBEG, i + 1, facade.arrayContext() :: stack)
-          case '{' => rparse(OBJBEG, i + 1, facade.objectContext() :: stack)
+      if (c == '[') {
+        rparse(ARRBEG, i + 1, facade.arrayContext() :: stack)
+      } else if (c == '{') {
+        rparse(OBJBEG, i + 1, facade.objectContext() :: stack)
+      } else {
+        val ctxt = stack.head
 
-          case '-' | '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' =>
-            val ctxt = stack.head
-            val j = parseNum(i, ctxt)
-            rparse(if (ctxt.isObj) OBJEND else ARREND, j, stack)
-
-          case '"' =>
-            val ctxt = stack.head
-            val j = parseString(i, ctxt)
-            rparse(if (ctxt.isObj) OBJEND else ARREND, j, stack)
-
-          case 't' =>
-            val ctxt = stack.head
-            ctxt.add(parseTrue(i))
-            rparse(if (ctxt.isObj) OBJEND else ARREND, i + 4, stack)
-
-          case 'f' =>
-            val ctxt = stack.head
-            ctxt.add(parseFalse(i))
-            rparse(if (ctxt.isObj) OBJEND else ARREND, i + 5, stack)
-
-          case 'n' =>
-            val ctxt = stack.head
-            ctxt.add(parseNull(i))
-            rparse(if (ctxt.isObj) OBJEND else ARREND, i + 4, stack)
-
-          case ' ' => rparse(state, i + 1, stack)
-          case '\t' => rparse(state, i + 1, stack)
-          case '\r' => rparse(state, i + 1, stack)
-          case '\n' => newline(i); rparse(state, i + 1, stack)
-
-          case _ =>
-            die(i, "expected json value")
+        if ((c >= '0' && c <= '9') || c == '-') {
+          val j = parseNum(i, ctxt)
+          rparse(if (ctxt.isObj) OBJEND else ARREND, j, stack)
+        } else if (c == '"') {
+          val j = parseString(i, ctxt)
+          rparse(if (ctxt.isObj) OBJEND else ARREND, j, stack)
+        } else if (c == 't') {
+          ctxt.add(parseTrue(i))
+          rparse(if (ctxt.isObj) OBJEND else ARREND, i + 4, stack)
+        } else if (c == 'f') {
+          ctxt.add(parseFalse(i))
+          rparse(if (ctxt.isObj) OBJEND else ARREND, i + 5, stack)
+        } else if (c == 'n') {
+          ctxt.add(parseNull(i))
+          rparse(if (ctxt.isObj) OBJEND else ARREND, i + 4, stack)
+        } else {
+          die(i, "expected json value")
         }
+      }
+    } else if (
+      (c == ']' && (state == ARREND || state == ARRBEG)) ||
+      (c == '}' && (state == OBJEND || state == OBJBEG))
+    ) {
+      // we are inside an array or object and have seen a key or a closing
+      // brace, respectively.
+      if (stack.isEmpty) {
+        error("invalid stack")
+      } else {
+        val ctxt1 = stack.head
+        val tail = stack.tail
 
-      // we are in an object expecting to see a key
-      case KEY =>
-        (at(i): @switch) match {
-          case '"' =>
-            val j = parseString(i, stack.head)
-            rparse(SEP, j, stack)
-
-          case ' ' => rparse(state, i + 1, stack)
-          case '\t' => rparse(state, i + 1, stack)
-          case '\r' => rparse(state, i + 1, stack)
-          case '\n' => newline(i); rparse(state, i + 1, stack)
-
-          case _ => die(i, "expected \"")
+        if (tail.isEmpty) {
+          (ctxt1.finish, i + 1)
+        } else {
+          val ctxt2 = tail.head
+          ctxt2.add(ctxt1.finish)
+          rparse(if (ctxt2.isObj) OBJEND else ARREND, i + 1, tail)
         }
-
-      // we are starting an array, expecting to see data or a closing bracket
-      case ARRBEG =>
-        (at(i): @switch) match {
-          case ']' =>
-            if (stack.isEmpty) {
-              error("invalid stack")
-            } else {
-              val ctxt1 = stack.head
-              val tail = stack.tail
-
-              if (tail.isEmpty) {
-                (ctxt1.finish, i + 1)
-              } else {
-                val ctxt2 = tail.head
-                ctxt2.add(ctxt1.finish)
-                rparse(if (ctxt2.isObj) OBJEND else ARREND, i + 1, tail)
-              }
-            }
-
-          case ' ' => rparse(state, i + 1, stack)
-          case '\t' => rparse(state, i + 1, stack)
-          case '\r' => rparse(state, i + 1, stack)
-          case '\n' => newline(i); rparse(state, i + 1, stack)
-
-          case _ => rparse(DATA, i, stack)
-        }
-
-      // we are starting an object, expecting to see a key or a closing brace
-      case OBJBEG =>
-        (at(i): @switch) match {
-          case '}' =>
-            if (stack.isEmpty) {
-              error("invalid stack")
-            } else {
-              val ctxt1 = stack.head
-              val tail = stack.tail
-
-              if (tail.isEmpty) {
-                (ctxt1.finish, i + 1)
-              } else {
-                val ctxt2 = tail.head
-                ctxt2.add(ctxt1.finish)
-                rparse(if (ctxt2.isObj) OBJEND else ARREND, i + 1, tail)
-              }
-            }
-
-          case ' ' => rparse(state, i + 1, stack)
-          case '\t' => rparse(state, i + 1, stack)
-          case '\r' => rparse(state, i + 1, stack)
-          case '\n' => newline(i); rparse(state, i + 1, stack)
-
-          case _ => rparse(KEY, i, stack)
-        }
-
-      // we are in an object just after a key, expecting to see a colon
-      case SEP =>
-        (at(i): @switch) match {
-          case ':' => rparse(DATA, i + 1, stack)
-
-          case ' ' => rparse(state, i + 1, stack)
-          case '\t' => rparse(state, i + 1, stack)
-          case '\r' => rparse(state, i + 1, stack)
-          case '\n' => newline(i); rparse(state, i + 1, stack)
-
-          case _ => die(i, "expected :")
-        }
-
-      // we are at a possible stopping point for an array, expecting to see
-      // either a comma (before more data) or a closing bracket.
-      case ARREND =>
-        (at(i): @switch) match {
-          case ',' => rparse(DATA, i + 1, stack)
-
-          case ']' =>
-            if (stack.isEmpty) {
-              error("invalid stack")
-            } else {
-              val ctxt1 = stack.head
-              val tail = stack.tail
-
-              if (tail.isEmpty) {
-                (ctxt1.finish, i + 1)
-              } else {
-                val ctxt2 = tail.head
-                ctxt2.add(ctxt1.finish)
-                rparse(if (ctxt2.isObj) OBJEND else ARREND, i + 1, tail)
-              }
-            }
-
-          case ' ' => rparse(state, i + 1, stack)
-          case '\t' => rparse(state, i + 1, stack)
-          case '\r' => rparse(state, i + 1, stack)
-          case '\n' => newline(i); rparse(state, i + 1, stack)
-
-          case _ => die(i, "expected ] or ,")
-        }
-
-      // we are at a possible stopping point for an object, expecting to see
-      // either a comma (before more data) or a closing brace.
-      case OBJEND =>
-        (at(i): @switch) match {
-          case ',' => rparse(KEY, i + 1, stack)
-
-          case '}' =>
-            if (stack.isEmpty) {
-              error("invalid stack")
-            } else {
-              val ctxt1 = stack.head
-              val tail = stack.tail
-
-              if (tail.isEmpty) {
-                (ctxt1.finish, i + 1)
-              } else {
-                val ctxt2 = tail.head
-                ctxt2.add(ctxt1.finish)
-                rparse(if (ctxt2.isObj) OBJEND else ARREND, i + 1, tail)
-              }
-            }
-
-          case ' ' => rparse(state, i + 1, stack)
-          case '\t' => rparse(state, i + 1, stack)
-          case '\r' => rparse(state, i + 1, stack)
-          case '\n' => newline(i); rparse(state, i + 1, stack)
-
-          case _ => die(i, "expected } or ,")
-        }
+      }
+    } else if (state == KEY) {
+      // we are in an object expecting to see a key.
+      if (c == '"') {
+        val j = parseString(i, stack.head)
+        rparse(SEP, j, stack)
+      } else {
+        die(i, "expected \"")
+      }
+    } else if (state == SEP) {
+      // we are in an object just after a key, expecting to see a colon.
+      if (c == ':') {
+        rparse(DATA, i + 1, stack)
+      } else {
+        die(i, "expected :")
+      }
+    } else if (state == ARREND) {
+      // we are in an array, expecting to see a comma (before more data).
+      if (c == ',') {
+        rparse(DATA, i + 1, stack)
+      } else {
+        die(i, "expected ] or ,")
+      }
+    } else if (state == OBJEND) {
+      // we are in an object, expecting to see a comma (before more data).
+      if (c == ',') {
+        rparse(KEY, i + 1, stack)
+      } else {
+        die(i, "expected } or ,")
+      }
+    } else if (state == ARRBEG) {
+      // we are starting an array, expecting to see data or a closing bracket.
+      rparse(DATA, i, stack)
+    } else {
+      // we are starting an object, expecting to see a key or a closing brace.
+      rparse(KEY, i, stack)
     }
   }
 }

--- a/parser/src/main/scala/jawn/Parser.scala
+++ b/parser/src/main/scala/jawn/Parser.scala
@@ -293,9 +293,11 @@ abstract class Parser[J] {
 
   /**
    * Parse the JSON constant "true".
+   *
+   * Note that this method assumes that the first character has already been checked.
    */
-  protected[this] final def parseTrue(i: Int)(implicit facade: Facade[J]) =
-    if (at(i) == 't' && at(i + 1) == 'r' && at(i + 2) == 'u' && at(i + 3) == 'e') {
+  protected[this] final def parseTrue(i: Int)(implicit facade: Facade[J]): J =
+    if (at(i + 1) == 'r' && at(i + 2) == 'u' && at(i + 3) == 'e') {
       facade.jtrue
     } else {
       die(i, "expected true")
@@ -303,9 +305,11 @@ abstract class Parser[J] {
 
   /**
    * Parse the JSON constant "false".
+   *
+   * Note that this method assumes that the first character has already been checked.
    */
-  protected[this] final def parseFalse(i: Int)(implicit facade: Facade[J]) =
-    if (at(i) == 'f' && at(i + 1) == 'a' && at(i + 2) == 'l' && at(i + 3) == 's' && at(i + 4) == 'e') {
+  protected[this] final def parseFalse(i: Int)(implicit facade: Facade[J]): J =
+    if (at(i + 1) == 'a' && at(i + 2) == 'l' && at(i + 3) == 's' && at(i + 4) == 'e') {
       facade.jfalse
     } else {
       die(i, "expected false")
@@ -313,9 +317,11 @@ abstract class Parser[J] {
 
   /**
    * Parse the JSON constant "null".
+   *
+   * Note that this method assumes that the first character has already been checked.
    */
-  protected[this] final def parseNull(i: Int)(implicit facade: Facade[J]) =
-    if (at(i) == 'n' && at(i + 1) == 'u' && at(i + 2) == 'l' && at(i + 3) == 'l') {
+  protected[this] final def parseNull(i: Int)(implicit facade: Facade[J]): J =
+    if (at(i + 1) == 'u' && at(i + 2) == 'l' && at(i + 3) == 'l') {
       facade.jnull
     } else {
       die(i, "expected null")

--- a/parser/src/main/scala/jawn/Parser.scala
+++ b/parser/src/main/scala/jawn/Parser.scala
@@ -445,15 +445,21 @@ abstract class Parser[J] {
       // we are starting an array, expecting to see data or a closing bracket
       case ARRBEG =>
         (at(i): @switch) match {
-          case ']' => stack match {
-            case ctxt1 :: Nil =>
-              (ctxt1.finish, i + 1)
-            case ctxt1 :: ctxt2 :: tail =>
-              ctxt2.add(ctxt1.finish)
-              rparse(if (ctxt2.isObj) OBJEND else ARREND, i + 1, ctxt2 :: tail)
-            case _ =>
+          case ']' =>
+            if (stack.isEmpty) {
               error("invalid stack")
-          }
+            } else {
+              val ctxt1 = stack.head
+              val tail = stack.tail
+
+              if (tail.isEmpty) {
+                (ctxt1.finish, i + 1)
+              } else {
+                val ctxt2 = tail.head
+                ctxt2.add(ctxt1.finish)
+                rparse(if (ctxt2.isObj) OBJEND else ARREND, i + 1, tail)
+              }
+            }
 
           case ' ' => rparse(state, i + 1, stack)
           case '\t' => rparse(state, i + 1, stack)
@@ -466,15 +472,21 @@ abstract class Parser[J] {
       // we are starting an object, expecting to see a key or a closing brace
       case OBJBEG =>
         (at(i): @switch) match {
-          case '}' => stack match {
-            case ctxt1 :: Nil =>
-              (ctxt1.finish, i + 1)
-            case ctxt1 :: ctxt2 :: tail =>
-              ctxt2.add(ctxt1.finish)
-              rparse(if (ctxt2.isObj) OBJEND else ARREND, i + 1, ctxt2 :: tail)
-            case _ =>
+          case '}' =>
+            if (stack.isEmpty) {
               error("invalid stack")
-          }
+            } else {
+              val ctxt1 = stack.head
+              val tail = stack.tail
+
+              if (tail.isEmpty) {
+                (ctxt1.finish, i + 1)
+              } else {
+                val ctxt2 = tail.head
+                ctxt2.add(ctxt1.finish)
+                rparse(if (ctxt2.isObj) OBJEND else ARREND, i + 1, tail)
+              }
+            }
 
           case ' ' => rparse(state, i + 1, stack)
           case '\t' => rparse(state, i + 1, stack)
@@ -503,15 +515,21 @@ abstract class Parser[J] {
         (at(i): @switch) match {
           case ',' => rparse(DATA, i + 1, stack)
 
-          case ']' => stack match {
-            case ctxt1 :: Nil =>
-              (ctxt1.finish, i + 1)
-            case ctxt1 :: ctxt2 :: tail =>
-              ctxt2.add(ctxt1.finish)
-              rparse(if (ctxt2.isObj) OBJEND else ARREND, i + 1, ctxt2 :: tail)
-            case _ =>
+          case ']' =>
+            if (stack.isEmpty) {
               error("invalid stack")
-          }
+            } else {
+              val ctxt1 = stack.head
+              val tail = stack.tail
+
+              if (tail.isEmpty) {
+                (ctxt1.finish, i + 1)
+              } else {
+                val ctxt2 = tail.head
+                ctxt2.add(ctxt1.finish)
+                rparse(if (ctxt2.isObj) OBJEND else ARREND, i + 1, tail)
+              }
+            }
 
           case ' ' => rparse(state, i + 1, stack)
           case '\t' => rparse(state, i + 1, stack)
@@ -527,15 +545,21 @@ abstract class Parser[J] {
         (at(i): @switch) match {
           case ',' => rparse(KEY, i + 1, stack)
 
-          case '}' => stack match {
-            case ctxt1 :: Nil =>
-              (ctxt1.finish, i + 1)
-            case ctxt1 :: ctxt2 :: tail =>
-              ctxt2.add(ctxt1.finish)
-              rparse(if (ctxt2.isObj) OBJEND else ARREND, i + 1, ctxt2 :: tail)
-            case _ =>
+          case '}' =>
+            if (stack.isEmpty) {
               error("invalid stack")
-          }
+            } else {
+              val ctxt1 = stack.head
+              val tail = stack.tail
+
+              if (tail.isEmpty) {
+                (ctxt1.finish, i + 1)
+              } else {
+                val ctxt2 = tail.head
+                ctxt2.add(ctxt1.finish)
+                rparse(if (ctxt2.isObj) OBJEND else ARREND, i + 1, tail)
+              }
+            }
 
           case ' ' => rparse(state, i + 1, stack)
           case '\t' => rparse(state, i + 1, stack)


### PR DESCRIPTION
This PR improves parsing performance a bit without changing behavior or binary compatibility. It also includes an easier way to run just the jawn benchmarks without the others for the sake of comparisons like this (i.e. not just commenting stuff out).

The biggest part of the change comes from changing cases like this:

```scala
  case ctxt1 :: ctxt2 :: tail =>
    ctxt2.add(ctxt1.finish)
    rparse(if (ctxt2.isObj) OBJEND else ARREND, i + 1, ctxt2 :: tail)
```

…so that we don't deconstruct `ctxt2 :: tail` and then immediately build an identical new one with `ctxt2 :: tail`. The other changes do help measurably as well, though, and rearranging the cases also makes things more concise.

Here are benchmark results without the last three commits on my machine:

```
Benchmark                               Mode  Cnt   Score   Error  Units
JawnOnlyBla25Bench.jawnCheckSyntax      avgt   50   7.307 ± 0.119  ms/op
JawnOnlyBla25Bench.jawnParse            avgt   50  10.815 ± 0.055  ms/op
JawnOnlyBla25Bench.jawnStringParse      avgt   50  10.831 ± 0.165  ms/op
JawnOnlyCountriesBench.jawnCheckSyntax  avgt   50   1.046 ± 0.017  ms/op
JawnOnlyCountriesBench.jawnParse        avgt   50   2.619 ± 0.041  ms/op
JawnOnlyCountriesBench.jawnStringParse  avgt   50   2.584 ± 0.030  ms/op
JawnOnlyQux2Bench.jawnCheckSyntax       avgt   50   2.362 ± 0.033  ms/op
JawnOnlyQux2Bench.jawnParse             avgt   50   3.360 ± 0.032  ms/op
JawnOnlyQux2Bench.jawnStringParse       avgt   50   3.362 ± 0.045  ms/op
JawnOnlyUgh10kBench.jawnCheckSyntax     avgt   50  15.851 ± 0.162  ms/op
JawnOnlyUgh10kBench.jawnParse           avgt   50  19.461 ± 0.153  ms/op
JawnOnlyUgh10kBench.jawnStringParse     avgt   50  19.517 ± 0.183  ms/op
```

And after the changes:

```
Benchmark                               Mode  Cnt   Score   Error  Units
JawnOnlyBla25Bench.jawnCheckSyntax      avgt   50   6.686 ± 0.087  ms/op
JawnOnlyBla25Bench.jawnParse            avgt   50  10.177 ± 0.192  ms/op
JawnOnlyBla25Bench.jawnStringParse      avgt   50  10.407 ± 0.118  ms/op
JawnOnlyCountriesBench.jawnCheckSyntax  avgt   50   1.009 ± 0.015  ms/op
JawnOnlyCountriesBench.jawnParse        avgt   50   2.423 ± 0.026  ms/op
JawnOnlyCountriesBench.jawnStringParse  avgt   50   2.394 ± 0.023  ms/op
JawnOnlyQux2Bench.jawnCheckSyntax       avgt   50   2.248 ± 0.024  ms/op
JawnOnlyQux2Bench.jawnParse             avgt   50   3.187 ± 0.051  ms/op
JawnOnlyQux2Bench.jawnStringParse       avgt   50   3.151 ± 0.026  ms/op
JawnOnlyUgh10kBench.jawnCheckSyntax     avgt   50  13.991 ± 0.099  ms/op
JawnOnlyUgh10kBench.jawnParse           avgt   50  18.388 ± 0.220  ms/op
JawnOnlyUgh10kBench.jawnStringParse     avgt   50  18.156 ± 0.340  ms/op
```

Allocations are also a little lower.

I tried a few other things that helped a bit, like manually unrolling the tail recursion into a `while` loop, and changing the signature of `rparse`, `checkpoint`, etc. to take a context head and tail instead of just a list (which is also semantically a little nicer in that some impossible cases don't have to be handled). These are more major changes, though, and they don't actually help that much, so I've left them out.