### PR TITLE
Replace String with CharSequence

### DIFF
--- a/ast/src/main/scala/jawn/ast/JawnFacade.scala
+++ b/ast/src/main/scala/jawn/ast/JawnFacade.scala
@@ -8,14 +8,14 @@ object JawnFacade extends Facade[JValue] {
   final val jnull = JNull
   final val jfalse = JFalse
   final val jtrue = JTrue
-  final def jnum(s: String) = DeferNum(s)
-  final def jint(s: String) = DeferLong(s)
-  final def jstring(s: String) = JString(s)
+  final def jnum(s: CharSequence) = DeferNum(s.toString)
+  final def jint(s: CharSequence) = DeferLong(s.toString)
+  final def jstring(s: CharSequence) = JString(s.toString)
 
   final def singleContext(): FContext[JValue] =
     new FContext[JValue] {
       var value: JValue = _
-      def add(s: String) { value = JString(s) }
+      def add(s: CharSequence) { value = JString(s.toString) }
       def add(v: JValue) { value = v }
       def finish: JValue = value
       def isObj: Boolean = false
@@ -24,7 +24,7 @@ object JawnFacade extends Facade[JValue] {
   final def arrayContext(): FContext[JValue] =
     new FContext[JValue] {
       val vs = mutable.ArrayBuffer.empty[JValue]
-      def add(s: String) { vs.append(JString(s)) }
+      def add(s: CharSequence) { vs.append(JString(s.toString)) }
       def add(v: JValue) { vs.append(v) }
       def finish: JValue = JArray(vs.toArray)
       def isObj: Boolean = false
@@ -34,8 +34,8 @@ object JawnFacade extends Facade[JValue] {
     new FContext[JValue] {
       var key: String = null
       val vs = mutable.Map.empty[String, JValue]
-      def add(s: String): Unit =
-        if (key == null) { key = s } else { vs(key) = JString(s); key = null }
+      def add(s: CharSequence): Unit =
+        if (key == null) { key = s.toString } else { vs(key.toString) = JString(s.toString); key = null }
       def add(v: JValue): Unit =
         { vs(key) = v; key = null }
       def finish = JObject(vs)

--- a/ast/src/test/scala/jawn/ParseCheck.scala
+++ b/ast/src/test/scala/jawn/ParseCheck.scala
@@ -77,6 +77,15 @@ class AstCheck extends PropSpec with Matchers with PropertyChecks {
 
   import AsyncParser.{UnwrapArray, ValueStream, SingleValue}
 
+  property("async multi") {
+    val data = "[1,2,3][4,5,6]"
+    val p = AsyncParser[JValue](ValueStream)
+    val res0 = p.absorb(data)
+    val res1 = p.finish
+    //println((res0, res1))
+    true
+  }
+
   property("async parsing") {
     forAll { (v: JValue) =>
       val json = CanonicalRenderer.render(v)

--- a/parser/src/main/scala/jawn/AsyncParser.scala
+++ b/parser/src/main/scala/jawn/AsyncParser.scala
@@ -289,7 +289,7 @@ final class AsyncParser[J] protected[jawn] (
    * boundaries. Also, the resulting String is not guaranteed to have length
    * (k - i).
    */
-  protected[this] final def at(i: Int, k: Int): String = {
+  protected[this] final def at(i: Int, k: Int): CharSequence = {
     if (k > len) throw new AsyncException
     val size = k - i
     val arr = new Array[Byte](size)

--- a/parser/src/main/scala/jawn/ByteBufferParser.scala
+++ b/parser/src/main/scala/jawn/ByteBufferParser.scala
@@ -29,7 +29,7 @@ final class ByteBufferParser[J](src: ByteBuffer) extends SyncParser[J] with Byte
   protected[this] final def byte(i: Int): Byte = src.get(i + start)
   protected[this] final def at(i: Int): Char = src.get(i + start).toChar
 
-  protected[this] final def at(i: Int, k: Int): String = {
+  protected[this] final def at(i: Int, k: Int): CharSequence = {
     val len = k - i
     val arr = new Array[Byte](len)
     src.position(i + start)

--- a/parser/src/main/scala/jawn/ChannelParser.scala
+++ b/parser/src/main/scala/jawn/ChannelParser.scala
@@ -140,7 +140,7 @@ final class ChannelParser[J](ch: ReadableByteChannel, bufferSize: Int) extends S
    * on unicode boundaries. Also, the resulting String is not
    * guaranteed to have length (k - i).
    */
-  protected[this] final def at(i: Int, k: Int): String = {
+  protected[this] final def at(i: Int, k: Int): CharSequence = {
     val len = k - i
     if (k > Allsize) {
       grow()

--- a/parser/src/main/scala/jawn/CharBuilder.scala
+++ b/parser/src/main/scala/jawn/CharBuilder.scala
@@ -34,7 +34,7 @@ private[jawn] final class CharBuilder {
     }
   }
 
-  def extend(s: String): Unit = {
+  def extend(s: CharSequence): Unit = {
     val tlen = len + s.length
     resizeIfNecessary(tlen)
     var i = 0

--- a/parser/src/main/scala/jawn/Facade.scala
+++ b/parser/src/main/scala/jawn/Facade.scala
@@ -3,7 +3,7 @@ package jawn
 /**
  * Facade is a type class that describes how Jawn should construct
  * JSON AST elements of type J.
- * 
+ *
  * Facade[J] also uses FContext[J] instances, so implementors will
  * usually want to define both.
  */
@@ -15,9 +15,9 @@ trait Facade[J] {
   def jnull(): J
   def jfalse(): J
   def jtrue(): J
-  def jnum(s: String): J
-  def jint(s: String): J
-  def jstring(s: String): J
+  def jnum(s: CharSequence): J
+  def jint(s: CharSequence): J
+  def jstring(s: CharSequence): J
 }
 
 /**
@@ -28,7 +28,7 @@ trait Facade[J] {
  * cases where the entire JSON document consists of "333.33".
  */
 trait FContext[J] {
-  def add(s: String): Unit
+  def add(s: CharSequence): Unit
   def add(v: J): Unit
   def finish: J
   def isObj: Boolean

--- a/parser/src/main/scala/jawn/MutableFacade.scala
+++ b/parser/src/main/scala/jawn/MutableFacade.scala
@@ -8,7 +8,7 @@ trait MutableFacade[J] extends Facade[J] {
 
   def singleContext() = new FContext[J] {
     var value: J = _
-    def add(s: String) { value = jstring(s) }
+    def add(s: CharSequence) { value = jstring(s) }
     def add(v: J) { value = v }
     def finish: J = value
     def isObj: Boolean = false
@@ -16,7 +16,7 @@ trait MutableFacade[J] extends Facade[J] {
 
   def arrayContext() = new FContext[J] {
     val vs = mutable.ArrayBuffer.empty[J]
-    def add(s: String) { vs.append(jstring(s)) }
+    def add(s: CharSequence) { vs.append(jstring(s)) }
     def add(v: J) { vs.append(v) }
     def finish: J = jarray(vs)
     def isObj: Boolean = false
@@ -25,8 +25,8 @@ trait MutableFacade[J] extends Facade[J] {
   def objectContext() = new FContext[J] {
     var key: String = null
     val vs = mutable.Map.empty[String, J]
-    def add(s: String): Unit =
-      if (key == null) { key = s } else { vs(key) = jstring(s); key = null }
+    def add(s: CharSequence): Unit =
+      if (key == null) { key = s.toString } else { vs(key) = jstring(s); key = null }
     def add(v: J): Unit =
       { vs(key) = v; key = null }
     def finish = jobject(vs)

--- a/parser/src/main/scala/jawn/NullFacade.scala
+++ b/parser/src/main/scala/jawn/NullFacade.scala
@@ -13,7 +13,7 @@ package jawn
 object NullFacade extends Facade[Unit] {
 
   case class NullContext(isObj: Boolean) extends FContext[Unit] {
-    def add(s: String): Unit = ()
+    def add(s: CharSequence): Unit = ()
     def add(v: Unit): Unit = ()
     def finish: Unit = ()
   }
@@ -25,7 +25,7 @@ object NullFacade extends Facade[Unit] {
   def jnull(): Unit = ()
   def jfalse(): Unit = ()
   def jtrue(): Unit = ()
-  def jnum(s: String): Unit = ()
-  def jint(s: String): Unit = ()
-  def jstring(s: String): Unit = ()
+  def jnum(s: CharSequence): Unit = ()
+  def jint(s: CharSequence): Unit = ()
+  def jstring(s: CharSequence): Unit = ()
 }

--- a/parser/src/main/scala/jawn/Parser.scala
+++ b/parser/src/main/scala/jawn/Parser.scala
@@ -46,7 +46,7 @@ abstract class Parser[J] {
   /**
    * Read the bytes/chars from 'i' until 'j' as a String.
    */
-  protected[this] def at(i: Int, j: Int): String
+  protected[this] def at(i: Int, j: Int): CharSequence
 
   /**
    * Return true iff 'i' is at or beyond the end of the input (EOF).
@@ -275,7 +275,7 @@ abstract class Parser[J] {
    * NOTE: This is only capable of generating characters from the basic plane.
    * This is why it can only return Char instead of Int.
    */
-  protected[this] final def descape(s: String): Char = {
+  protected[this] final def descape(s: CharSequence): Char = {
     val hc = HexChars
     var i = 0
     var x = 0

--- a/parser/src/main/scala/jawn/SimpleFacade.scala
+++ b/parser/src/main/scala/jawn/SimpleFacade.scala
@@ -5,7 +5,7 @@ import scala.collection.mutable
 /**
  * Facade is a type class that describes how Jawn should construct
  * JSON AST elements of type J.
- * 
+ *
  * Facade[J] also uses FContext[J] instances, so implementors will
  * usually want to define both.
  */
@@ -15,7 +15,7 @@ trait SimpleFacade[J] extends Facade[J] {
 
   def singleContext() = new FContext[J] {
     var value: J = _
-    def add(s: String) { value = jstring(s) }
+    def add(s: CharSequence) { value = jstring(s) }
     def add(v: J) { value = v }
     def finish: J = value
     def isObj: Boolean = false
@@ -23,7 +23,7 @@ trait SimpleFacade[J] extends Facade[J] {
 
   def arrayContext() = new FContext[J] {
     val vs = mutable.ListBuffer.empty[J]
-    def add(s: String) { vs += jstring(s) }
+    def add(s: CharSequence) { vs += jstring(s) }
     def add(v: J) { vs += v }
     def finish: J = jarray(vs.toList)
     def isObj: Boolean = false
@@ -32,8 +32,8 @@ trait SimpleFacade[J] extends Facade[J] {
   def objectContext() = new FContext[J] {
     var key: String = null
     var vs = Map.empty[String, J]
-    def add(s: String): Unit =
-      if (key == null) { key = s } else { vs = vs.updated(key, jstring(s)); key = null }
+    def add(s: CharSequence): Unit =
+      if (key == null) { key = s.toString } else { vs = vs.updated(key, jstring(s)); key = null }
     def add(v: J): Unit =
       { vs = vs.updated(key, v); key = null }
     def finish = jobject(vs)

--- a/parser/src/main/scala/jawn/StringParser.scala
+++ b/parser/src/main/scala/jawn/StringParser.scala
@@ -19,7 +19,7 @@ private[jawn] final class StringParser[J](s: String) extends SyncParser[J] with 
   final def reset(i: Int): Int = i
   final def checkpoint(state: Int, i: Int, stack: List[FContext[J]]) {}
   final def at(i: Int): Char = s.charAt(i)
-  final def at(i: Int, j: Int): String = s.substring(i, j)
+  final def at(i: Int, j: Int): CharSequence = s.substring(i, j)
   final def atEof(i: Int) = i == s.length
   final def close() = ()
 }

--- a/support/argonaut/src/main/scala/Parser.scala
+++ b/support/argonaut/src/main/scala/Parser.scala
@@ -10,13 +10,13 @@ object Parser extends SupportParser[Json] {
       def jnull() = Json.jNull
       def jfalse() = Json.jFalse
       def jtrue() = Json.jTrue
-      def jnum(s: String) = Json.jNumber(JsonNumber.unsafeDecimal(s))
-      def jint(s: String) = Json.jNumber(JsonNumber.unsafeDecimal(s))
-      def jstring(s: String) = Json.jString(s)
+      def jnum(s: CharSequence) = Json.jNumber(JsonNumber.unsafeDecimal(s.toString))
+      def jint(s: CharSequence) = Json.jNumber(JsonNumber.unsafeDecimal(s.toString))
+      def jstring(s: CharSequence) = Json.jString(s.toString)
 
       def singleContext() = new FContext[Json] {
         var value: Json = null
-        def add(s: String) { value = jstring(s) }
+        def add(s: CharSequence) { value = jstring(s) }
         def add(v: Json) { value = v }
         def finish: Json = value
         def isObj: Boolean = false
@@ -24,7 +24,7 @@ object Parser extends SupportParser[Json] {
 
       def arrayContext() = new FContext[Json] {
         val vs = mutable.ListBuffer.empty[Json]
-        def add(s: String) { vs += jstring(s) }
+        def add(s: CharSequence) { vs += jstring(s) }
         def add(v: Json) { vs += v }
         def finish: Json = Json.jArray(vs.toList)
         def isObj: Boolean = false
@@ -33,8 +33,8 @@ object Parser extends SupportParser[Json] {
       def objectContext() = new FContext[Json] {
         var key: String = null
         var vs = JsonObject.empty
-        def add(s: String): Unit =
-          if (key == null) { key = s } else { vs = vs + (key, jstring(s)); key = null }
+        def add(s: CharSequence): Unit =
+          if (key == null) { key = s.toString } else { vs = vs + (key, jstring(s)); key = null }
         def add(v: Json): Unit =
         { vs = vs + (key, v); key = null }
         def finish = Json.jObject(vs)

--- a/support/json4s/src/main/scala/Parser.scala
+++ b/support/json4s/src/main/scala/Parser.scala
@@ -13,14 +13,18 @@ class Parser(useBigDecimalForDouble: Boolean, useBigIntForLong: Boolean) extends
       def jnull() = JNull
       def jfalse() = JBool(false)
       def jtrue() = JBool(true)
-      def jnum(s: String) = if (useBigDecimalForDouble) JDecimal(BigDecimal(s)) else JDouble(s.toDouble)
-      def jint(s: String) = if (useBigIntForLong) JInt(BigInt(s)) else JLong(s.toLong)
-      def jstring(s: String) = JString(s)
+      def jnum(s: CharSequence) =
+        if (useBigDecimalForDouble) JDecimal(BigDecimal(s.toString))
+        else JDouble(s.toString.toDouble)
+      def jint(s: CharSequence) =
+        if (useBigIntForLong) JInt(BigInt(s.toString))
+        else JLong(s.toString.toLong)
+      def jstring(s: CharSequence) = JString(s.toString)
 
       def singleContext() =
         new FContext[JValue] {
           var value: JValue = null
-          def add(s: String) { value = jstring(s) }
+          def add(s: CharSequence) { value = jstring(s) }
           def add(v: JValue) { value = v }
           def finish: JValue = value
           def isObj: Boolean = false
@@ -29,7 +33,7 @@ class Parser(useBigDecimalForDouble: Boolean, useBigIntForLong: Boolean) extends
       def arrayContext() =
         new FContext[JValue] {
           val vs = mutable.ListBuffer.empty[JValue]
-          def add(s: String) { vs += jstring(s) }
+          def add(s: CharSequence) { vs += jstring(s) }
           def add(v: JValue) { vs += v }
           def finish: JValue = JArray(vs.toList)
           def isObj: Boolean = false
@@ -39,8 +43,8 @@ class Parser(useBigDecimalForDouble: Boolean, useBigIntForLong: Boolean) extends
         new FContext[JValue] {
           var key: String = null
           val vs = mutable.ListBuffer.empty[JField]
-          def add(s: String): Unit =
-            if (key == null) key = s
+          def add(s: CharSequence): Unit =
+            if (key == null) key = s.toString
             else { vs += JField(key, jstring(s)); key = null }
           def add(v: JValue): Unit =
             { vs += JField(key, v); key = null }

--- a/support/play/src/main/scala/Parser.scala
+++ b/support/play/src/main/scala/Parser.scala
@@ -10,9 +10,9 @@ object Parser extends SupportParser[JsValue] {
       def jnull() = JsNull
       def jfalse() = JsBoolean(false)
       def jtrue() = JsBoolean(true)
-      def jnum(s: String) = JsNumber(BigDecimal(s))
-      def jint(s: String) = JsNumber(BigDecimal(s))
-      def jstring(s: String) = JsString(s)
+      def jnum(s: CharSequence) = JsNumber(BigDecimal(s.toString))
+      def jint(s: CharSequence) = JsNumber(BigDecimal(s.toString))
+      def jstring(s: CharSequence) = JsString(s.toString)
       def jarray(vs: List[JsValue]) = JsArray(vs)
       def jobject(vs: Map[String, JsValue]) = JsObject(vs)
     }

--- a/support/rojoma-v3/src/main/scala/Parser.scala
+++ b/support/rojoma-v3/src/main/scala/Parser.scala
@@ -10,9 +10,9 @@ object Parser extends SupportParser[JValue] {
       def jnull() = JNull
       def jfalse() = JBoolean.canonicalFalse
       def jtrue() = JBoolean.canonicalTrue
-      def jnum(s: String) = JNumber.unsafeFromString(s)
-      def jint(s: String) = JNumber.unsafeFromString(s)
-      def jstring(s: String) = JString(s)
+      def jnum(s: CharSequence) = JNumber.unsafeFromString(s.toString)
+      def jint(s: CharSequence) = JNumber.unsafeFromString(s.toString)
+      def jstring(s: CharSequence) = JString(s.toString)
       def jarray(vs: mutable.ArrayBuffer[JValue]) = JArray(vs)
       def jobject(vs: mutable.Map[String, JValue]) = JObject(vs)
     }

--- a/support/rojoma/src/main/scala/Parser.scala
+++ b/support/rojoma/src/main/scala/Parser.scala
@@ -10,9 +10,9 @@ object Parser extends SupportParser[JValue] {
       def jnull() = JNull
       def jfalse() = JBoolean.canonicalFalse
       def jtrue() = JBoolean.canonicalTrue
-      def jnum(s: String) = JNumber(BigDecimal(s))
-      def jint(s: String) = JNumber(BigDecimal(s))
-      def jstring(s: String) = JString(s)
+      def jnum(s: CharSequence) = JNumber(BigDecimal(s.toString))
+      def jint(s: CharSequence) = JNumber(BigDecimal(s.toString))
+      def jstring(s: CharSequence) = JString(s.toString)
       def jarray(vs: mutable.ArrayBuffer[JValue]) = JArray(vs)
       def jobject(vs: mutable.Map[String, JValue]) = JObject(vs)
     }

--- a/support/spray/src/main/scala/Parser.scala
+++ b/support/spray/src/main/scala/Parser.scala
@@ -9,9 +9,9 @@ object Parser extends SupportParser[JsValue] {
       def jnull() = JsNull
       def jfalse() = JsFalse
       def jtrue() = JsTrue
-      def jnum(s: String) = JsNumber(s)
-      def jint(s: String) = JsNumber(s)
-      def jstring(s: String) = JsString(s)
+      def jnum(s: CharSequence) = JsNumber(s.toString)
+      def jint(s: CharSequence) = JsNumber(s.toString)
+      def jstring(s: CharSequence) = JsString(s.toString)
       def jarray(vs: List[JsValue]) = JsArray(vs: _*)
       def jobject(vs: Map[String, JsValue]) = JsObject(vs)
     }


### PR DESCRIPTION
I changed my mind on #81—it's a pretty big change and it's not really necessary for me to get the improvements I want in circe. Instead of switching to `CharSequence` _and_ giving slices to the facade, this PR switches to `CharSequence` but all of the parsers in jawn itself just use ordinary strings.

This means no surprises for current users (except that they have to call `toString` on the `CharSequences`, which will be a no-op), but I can also implement my own `StringParser` and `ByteBuffer` parser in circe that use slices in exactly the places where they help, since I've got the `CharSequence` signatures to work with.

So it's still a breaking change in terms of API compatibility, but behind the scenes in jawn everything happens exactly the same way it did in 0.10.