### PR TITLE
Make CharBasedParser public

### DIFF
--- a/parser/src/main/scala/jawn/CharBasedParser.scala
+++ b/parser/src/main/scala/jawn/CharBasedParser.scala
@@ -11,7 +11,7 @@ import scala.annotation.{switch, tailrec}
  *
  * It is simpler than ByteBasedParser.
  */
-private[jawn] trait CharBasedParser[J] extends Parser[J] {
+trait CharBasedParser[J] extends Parser[J] {
 
   private[this] final val charBuilder = new CharBuilder()
 


### PR DESCRIPTION
There's a lot of copy-paste involved in defining a custom `StringParser` since `CharBasedParser` is private. This PR just makes it public, which is also consistent with `ByteBasedParser` (which is public).