### PR TITLE
AsyncParser can get into bad state due to reset

### DIFF
--- a/parser/src/main/scala/jawn/AsyncParser.scala
+++ b/parser/src/main/scala/jawn/AsyncParser.scala
@@ -243,15 +243,16 @@ final class AsyncParser[J] protected[jawn] (
     }
   }
 
-  // every 1M we shift our array back by 1M.
+  // every 1M we shift our array back to the beginning.
   protected[this] final def reset(i: Int): Int = {
     if (offset >= 1048576) {
-      curr -= 1048576
-      len -= 1048576
-      offset -= 1048576
-      pos -= 1048576
-      System.arraycopy(data, 1048576, data, 0, len)
-      i - 1048576
+      val diff = offset
+      curr -= diff
+      len -= diff
+      offset = 0
+      pos -= diff
+      System.arraycopy(data, diff, data, 0, len)
+      i - diff
     } else {
       i
     }

--- a/parser/src/main/scala/jawn/AsyncParser.scala
+++ b/parser/src/main/scala/jawn/AsyncParser.scala
@@ -246,6 +246,7 @@ final class AsyncParser[J] protected[jawn] (
   // every 1M we shift our array back by 1M.
   protected[this] final def reset(i: Int): Int = {
     if (offset >= 1048576) {
+      curr -= 1048576
       len -= 1048576
       offset -= 1048576
       pos -= 1048576


### PR DESCRIPTION
The following code can cause the parser to get into an invalid state:

```
    import io.circe.Json
    import jawn.{AsyncParser, Parser}
    import io.circe.jawn.CirceSupportParser.facade

    val p = Parser.async[Json](AsyncParser.UnwrapArray)
    p.absorb(s"[{${" " * (10 * 1024 * 1024)}},{")
    p.absorb("}]")
    p.finish().left.foreach(throw _)
```

This is due to AsyncParser.curr not being shifted back during reset.

I have added 2 changes, the first is to shift curr back on reset, and the other is to shift the array bac kto the beginning on reset as a lot of wasteful copying can occur if the reset only goes back 1MB at a time.