### PR TITLE
RFC: Expose the current parse index to Facade/FContext

### DIFF
--- a/ast/src/main/scala/jawn/ast/JValue.scala
+++ b/ast/src/main/scala/jawn/ast/JValue.scala
@@ -59,7 +59,7 @@ sealed abstract class JValue {
 }
 
 object JValue {
-  implicit val facade: Facade[JValue] = JawnFacade
+  implicit val facade: RawFacade[JValue] = JawnFacade
 }
 
 sealed abstract class JAtom extends JValue {

--- a/ast/src/main/scala/jawn/ast/JawnFacade.scala
+++ b/ast/src/main/scala/jawn/ast/JawnFacade.scala
@@ -19,7 +19,7 @@ object JawnFacade extends Facade[JValue] {
   final def jstring(s: CharSequence): JValue =
     JString(s.toString)
 
-  final def singleContext(): FContext[JValue] =
+  final def singleContext(): RawFContext[JValue] =
     new FContext[JValue] {
       var value: JValue = _
       def add(s: CharSequence) { value = JString(s.toString) }
@@ -28,7 +28,7 @@ object JawnFacade extends Facade[JValue] {
       def isObj: Boolean = false
     }
 
-  final def arrayContext(): FContext[JValue] =
+  final def arrayContext(): RawFContext[JValue] =
     new FContext[JValue] {
       val vs = mutable.ArrayBuffer.empty[JValue]
       def add(s: CharSequence) { vs.append(JString(s.toString)) }
@@ -37,7 +37,7 @@ object JawnFacade extends Facade[JValue] {
       def isObj: Boolean = false
     }
 
-  final def objectContext(): FContext[JValue] =
+  final def objectContext(): RawFContext[JValue] =
     new FContext[JValue] {
       var key: String = null
       val vs = mutable.Map.empty[String, JValue]

--- a/parser/src/main/scala/jawn/AsyncParser.scala
+++ b/parser/src/main/scala/jawn/AsyncParser.scala
@@ -60,7 +60,7 @@ object AsyncParser {
 final class AsyncParser[J] protected[jawn] (
   protected[jawn] var state: Int,
   protected[jawn] var curr: Int,
-  protected[jawn] var stack: List[FContext[J]],
+  protected[jawn] var stack: List[RawFContext[J]],
   protected[jawn] var data: Array[Byte],
   protected[jawn] var len: Int,
   protected[jawn] var allocated: Int,
@@ -77,7 +77,7 @@ final class AsyncParser[J] protected[jawn] (
   final def copy() =
     new AsyncParser(state, curr, stack, data.clone, len, allocated, offset, done, streamMode)
 
-  final def absorb(buf: ByteBuffer)(implicit facade: Facade[J]): Either[ParseException, Seq[J]] = {
+  final def absorb(buf: ByteBuffer)(implicit facade: RawFacade[J]): Either[ParseException, Seq[J]] = {
     done = false
     val buflen = buf.limit - buf.position
     val need = len + buflen
@@ -87,13 +87,13 @@ final class AsyncParser[J] protected[jawn] (
     churn()
   }
 
-  final def absorb(bytes: Array[Byte])(implicit facade: Facade[J]): Either[ParseException, Seq[J]] =
+  final def absorb(bytes: Array[Byte])(implicit facade: RawFacade[J]): Either[ParseException, Seq[J]] =
     absorb(ByteBuffer.wrap(bytes))
 
-  final def absorb(s: String)(implicit facade: Facade[J]): Either[ParseException, Seq[J]] =
+  final def absorb(s: String)(implicit facade: RawFacade[J]): Either[ParseException, Seq[J]] =
     absorb(ByteBuffer.wrap(s.getBytes(utf8)))
 
-  final def finish()(implicit facade: Facade[J]): Either[ParseException, Seq[J]] = {
+  final def finish()(implicit facade: RawFacade[J]): Either[ParseException, Seq[J]] = {
     done = true
     churn()
   }
@@ -140,7 +140,7 @@ final class AsyncParser[J] protected[jawn] (
   @inline private[this] final def ASYNC_POSTVAL = -2
   @inline private[this] final def ASYNC_PREVAL = -1
 
-  protected[jawn] def churn()(implicit facade: Facade[J]): Either[ParseException, Seq[J]] = {
+  protected[jawn] def churn()(implicit facade: RawFacade[J]): Either[ParseException, Seq[J]] = {
 
     // accumulates json values
     val results = mutable.ArrayBuffer.empty[J]
@@ -267,7 +267,7 @@ final class AsyncParser[J] protected[jawn] (
    * arguments are the exact arguments we can pass to rparse to
    * continue where we left off.
    */
-  protected[this] final def checkpoint(state: Int, i: Int, stack: List[FContext[J]]) {
+  protected[this] final def checkpoint(state: Int, i: Int, stack: List[RawFContext[J]]) {
     this.state = state
     this.curr = i
     this.stack = stack

--- a/parser/src/main/scala/jawn/ByteBasedParser.scala
+++ b/parser/src/main/scala/jawn/ByteBasedParser.scala
@@ -25,7 +25,7 @@ trait ByteBasedParser[J] extends Parser[J] {
    * This method expects the data to be in UTF-8 and accesses it as bytes. Thus
    * we can just ignore any bytes with the highest bit set.
    */
-  protected[this] final def parseStringSimple(i: Int, ctxt: FContext[J]): Int = {
+  protected[this] final def parseStringSimple(i: Int, ctxt: RawFContext[J]): Int = {
     var j = i
     var c: Int = byte(j) & 0xff
     while (c != 34) {
@@ -42,10 +42,10 @@ trait ByteBasedParser[J] extends Parser[J] {
    *
    * This method expects the data to be in UTF-8 and accesses it as bytes.
    */
-  protected[this] final def parseString(i: Int, ctxt: FContext[J]): Int = {
+  protected[this] final def parseString(i: Int, ctxt: RawFContext[J]): Int = {
     val k = parseStringSimple(i + 1, ctxt)
     if (k != -1) {
-      ctxt.add(at(i + 1, k - 1))
+      ctxt.add(at(i + 1, k - 1), i)
       return k
     }
 
@@ -98,7 +98,7 @@ trait ByteBasedParser[J] extends Parser[J] {
       }
       c = byte(j) & 0xff
     }
-    ctxt.add(sb.makeString)
+    ctxt.add(sb.makeString, i)
     j + 1
   }
 }

--- a/parser/src/main/scala/jawn/ByteBufferParser.scala
+++ b/parser/src/main/scala/jawn/ByteBufferParser.scala
@@ -25,7 +25,7 @@ final class ByteBufferParser[J](src: ByteBuffer) extends SyncParser[J] with Byte
 
   protected[this] final def close() { src.position(src.limit) }
   protected[this] final def reset(i: Int): Int = i
-  protected[this] final def checkpoint(state: Int, i: Int, stack: List[FContext[J]]) {}
+  protected[this] final def checkpoint(state: Int, i: Int, stack: List[RawFContext[J]]) {}
   protected[this] final def byte(i: Int): Byte = src.get(i + start)
   protected[this] final def at(i: Int): Char = src.get(i + start).toChar
 

--- a/parser/src/main/scala/jawn/ChannelParser.scala
+++ b/parser/src/main/scala/jawn/ChannelParser.scala
@@ -112,7 +112,7 @@ final class ChannelParser[J](ch: ReadableByteChannel, bufferSize: Int) extends S
       i
     }
 
-  protected[this] final def checkpoint(state: Int, i: Int, stack: List[FContext[J]]): Unit = ()
+  protected[this] final def checkpoint(state: Int, i: Int, stack: List[RawFContext[J]]): Unit = ()
 
   /**
    * This is a specialized accessor for the case where our underlying

--- a/parser/src/main/scala/jawn/CharBasedParser.scala
+++ b/parser/src/main/scala/jawn/CharBasedParser.scala
@@ -22,7 +22,7 @@ trait CharBasedParser[J] extends Parser[J] {
    * This method expects the data to be in UTF-16 and accesses it as
    * chars.
    */
-  protected[this] final def parseStringSimple(i: Int, ctxt: FContext[J]): Int = {
+  protected[this] final def parseStringSimple(i: Int, ctxt: RawFContext[J]): Int = {
     var j = i
     var c = at(j)
     while (c != '"') {
@@ -37,7 +37,7 @@ trait CharBasedParser[J] extends Parser[J] {
   /**
    * Parse a string that is known to have escape sequences.
    */
-  protected[this] final def parseStringComplex(i: Int, ctxt: FContext[J]): Int = {
+  protected[this] final def parseStringComplex(i: Int, ctxt: RawFContext[J]): Int = {
     var j = i + 1
     val sb = charBuilder.reset()
 
@@ -74,7 +74,7 @@ trait CharBasedParser[J] extends Parser[J] {
       j = reset(j)
       c = at(j)
     }
-    ctxt.add(sb.makeString)
+    ctxt.add(sb.makeString, i)
     j + 1
   }
 
@@ -86,10 +86,10 @@ trait CharBasedParser[J] extends Parser[J] {
    * Char. It performs the correct checks to make sure that we don't
    * interpret a multi-char code point incorrectly.
    */
-  protected[this] final def parseString(i: Int, ctxt: FContext[J]): Int = {
+  protected[this] final def parseString(i: Int, ctxt: RawFContext[J]): Int = {
     val k = parseStringSimple(i + 1, ctxt)
     if (k != -1) {
-      ctxt.add(at(i + 1, k - 1))
+      ctxt.add(at(i + 1, k - 1), i)
       k
     } else {
       parseStringComplex(i, ctxt)

--- a/parser/src/main/scala/jawn/CharSequenceParser.scala
+++ b/parser/src/main/scala/jawn/CharSequenceParser.scala
@@ -10,7 +10,7 @@ private[jawn] final class CharSequenceParser[J](cs: CharSequence) extends SyncPa
   final def column(i: Int) = i
   final def newline(i: Int) { line += 1 }
   final def reset(i: Int): Int = i
-  final def checkpoint(state: Int, i: Int, stack: List[FContext[J]]): Unit = ()
+  final def checkpoint(state: Int, i: Int, stack: List[RawFContext[J]]): Unit = ()
   final def at(i: Int): Char = cs.charAt(i)
   final def at(i: Int, j: Int): CharSequence = cs.subSequence(i, j)
   final def atEof(i: Int) = i == cs.length

--- a/parser/src/main/scala/jawn/Facade.scala
+++ b/parser/src/main/scala/jawn/Facade.scala
@@ -7,16 +7,45 @@ package jawn
  * Facade[J] also uses FContext[J] instances, so implementors will
  * usually want to define both.
  */
-trait Facade[J] {
-  def singleContext(): FContext[J]
-  def arrayContext(): FContext[J]
-  def objectContext(): FContext[J]
+trait Facade[J] extends RawFacade[J]{
+  def singleContext(): RawFContext[J]
+  def arrayContext(): RawFContext[J]
+  def objectContext(): RawFContext[J]
 
   def jnull(): J
   def jfalse(): J
   def jtrue(): J
   def jnum(s: CharSequence, decIndex: Int, expIndex: Int): J
   def jstring(s: CharSequence): J
+
+  def singleContext(index: Int) = singleContext()
+  def arrayContext(index: Int) = arrayContext()
+  def objectContext(index: Int) = objectContext()
+
+  def jnull(index: Int) = jnull()
+  def jfalse(index: Int) = jfalse()
+  def jtrue(index: Int) = jtrue()
+  def jnum(s: CharSequence, decIndex: Int, expIndex: Int, index: Int) =
+    jnum(s, decIndex, expIndex)
+  def jstring(s: CharSequence, index: Int) = jstring(s)
+}
+/**
+ * Facade is a type class that describes how Jawn should construct
+ * JSON AST elements of type J.
+ *
+ * Facade[J] also uses FContext[J] instances, so implementors will
+ * usually want to define both.
+ */
+trait RawFacade[J] {
+  def singleContext(index: Int): RawFContext[J]
+  def arrayContext(index: Int): RawFContext[J]
+  def objectContext(index: Int): RawFContext[J]
+
+  def jnull(index: Int): J
+  def jfalse(index: Int): J
+  def jtrue(index: Int): J
+  def jnum(s: CharSequence, decIndex: Int, expIndex: Int, index: Int): J
+  def jstring(s: CharSequence, index: Int): J
 }
 
 /**
@@ -26,9 +55,29 @@ trait Facade[J] {
  * this type is also used to build a single top-level JSON element, in
  * cases where the entire JSON document consists of "333.33".
  */
-trait FContext[J] {
+trait FContext[J] extends RawFContext[J]{
   def add(s: CharSequence): Unit
   def add(v: J): Unit
-  def finish: J
+  def finish(): J
+
+
+  def add(s: CharSequence, index: Int) = add(s)
+  def add(v: J, index: Int) = add(v)
+  def finish(index: Int) = finish()
+
+  def isObj: Boolean
+}
+
+/**
+ * FContext is used to construct nested JSON values.
+ *
+ * The most common cases are to build objects and arrays. However,
+ * this type is also used to build a single top-level JSON element, in
+ * cases where the entire JSON document consists of "333.33".
+ */
+trait RawFContext[J] {
+  def add(s: CharSequence, index: Int): Unit
+  def add(v: J, index: Int): Unit
+  def finish(index: Int): J
   def isObj: Boolean
 }

--- a/parser/src/main/scala/jawn/NullFacade.scala
+++ b/parser/src/main/scala/jawn/NullFacade.scala
@@ -18,9 +18,9 @@ object NullFacade extends Facade[Unit] {
     def finish: Unit = ()
   }
 
-  val singleContext: FContext[Unit] = NullContext(false)
-  val arrayContext: FContext[Unit] = NullContext(false)
-  val objectContext: FContext[Unit] = NullContext(true)
+  val singleContext: RawFContext[Unit] = NullContext(false)
+  val arrayContext: RawFContext[Unit] = NullContext(false)
+  val objectContext: RawFContext[Unit] = NullContext(true)
 
   def jnull(): Unit = ()
   def jfalse(): Unit = ()

--- a/parser/src/main/scala/jawn/StringParser.scala
+++ b/parser/src/main/scala/jawn/StringParser.scala
@@ -17,7 +17,7 @@ private[jawn] final class StringParser[J](s: String) extends SyncParser[J] with 
   final def column(i: Int) = i
   final def newline(i: Int) { line += 1 }
   final def reset(i: Int): Int = i
-  final def checkpoint(state: Int, i: Int, stack: List[FContext[J]]): Unit = ()
+  final def checkpoint(state: Int, i: Int, stack: List[RawFContext[J]]): Unit = ()
   final def at(i: Int): Char = s.charAt(i)
   final def at(i: Int, j: Int): CharSequence = s.substring(i, j)
   final def atEof(i: Int) = i == s.length

--- a/parser/src/main/scala/jawn/SupportParser.scala
+++ b/parser/src/main/scala/jawn/SupportParser.scala
@@ -6,7 +6,7 @@ import java.nio.channels.ReadableByteChannel
 import scala.util.Try
 
 trait SupportParser[J] {
-  implicit def facade: Facade[J]
+  implicit def facade: RawFacade[J]
 
   def parseUnsafe(s: String): J =
     new StringParser(s).parse()

--- a/parser/src/main/scala/jawn/SyncParser.scala
+++ b/parser/src/main/scala/jawn/SyncParser.scala
@@ -20,7 +20,7 @@ abstract class SyncParser[J] extends Parser[J] {
    * valid, as well as more traditional documents like [1,2,3,4,5]. However,
    * multiple top-level objects are not allowed.
    */
-  final def parse()(implicit facade: Facade[J]): J = {
+  final def parse()(implicit facade: RawFacade[J]): J = {
     val (value, i) = parse(0)
     var j = i
     while (!atEof(j)) {

--- a/parser/src/main/scala/jawn/Syntax.scala
+++ b/parser/src/main/scala/jawn/Syntax.scala
@@ -8,7 +8,7 @@ import scala.annotation.{switch, tailrec}
 import scala.util.Try
 
 object Syntax {
-  implicit def unitFacade: Facade[Unit] = NullFacade
+  implicit def unitFacade: RawFacade[Unit] = NullFacade
 
   def checkString(s: String): Boolean =
     Try(new StringParser(s).parse).isSuccess

--- a/parser/src/test/scala/jawn/JNumIndexCheck.scala
+++ b/parser/src/test/scala/jawn/JNumIndexCheck.scala
@@ -17,9 +17,9 @@ class JNumIndexCheck extends PropSpec with Matchers with PropertyChecks {
       def finish: Boolean = !failed
     }
 
-    val singleContext: FContext[Boolean] = new JNumIndexCheckContext(false)
-    val arrayContext: FContext[Boolean] = new JNumIndexCheckContext(false)
-    val objectContext: FContext[Boolean] = new JNumIndexCheckContext(true)
+    val singleContext: RawFContext[Boolean] = new JNumIndexCheckContext(false)
+    val arrayContext: RawFContext[Boolean] = new JNumIndexCheckContext(false)
+    val objectContext: RawFContext[Boolean] = new JNumIndexCheckContext(true)
 
     def jnull(): Boolean = true
     def jfalse(): Boolean = true

--- a/support/argonaut/src/main/scala/Parser.scala
+++ b/support/argonaut/src/main/scala/Parser.scala
@@ -5,7 +5,7 @@ import scala.collection.mutable
 import argonaut._
 
 object Parser extends SupportParser[Json] {
-  implicit val facade: Facade[Json] =
+  implicit val facade: RawFacade[Json] =
     new Facade[Json] {
       def jnull() = Json.jNull
       def jfalse() = Json.jFalse

--- a/support/json4s/src/main/scala/Parser.scala
+++ b/support/json4s/src/main/scala/Parser.scala
@@ -8,7 +8,7 @@ object Parser extends Parser(false, false)
 
 class Parser(useBigDecimalForDouble: Boolean, useBigIntForLong: Boolean) extends SupportParser[JValue] {
 
-  implicit val facade: Facade[JValue] =
+  implicit val facade: RawFacade[JValue] =
     new Facade[JValue] {
       def jnull() = JNull
       def jfalse() = JBool(false)

--- a/support/play/src/main/scala/Parser.scala
+++ b/support/play/src/main/scala/Parser.scala
@@ -5,7 +5,7 @@ import play.api.libs.json._
 
 object Parser extends SupportParser[JsValue] {
 
-  implicit val facade: Facade[JsValue] =
+  implicit val facade: RawFacade[JsValue] =
     new SimpleFacade[JsValue] {
       def jnull() = JsNull
       def jfalse() = JsBoolean(false)

--- a/support/rojoma-v3/src/main/scala/Parser.scala
+++ b/support/rojoma-v3/src/main/scala/Parser.scala
@@ -5,7 +5,7 @@ import scala.collection.mutable
 import com.rojoma.json.v3.ast._
 
 object Parser extends SupportParser[JValue] {
-  implicit val facade: Facade[JValue] =
+  implicit val facade: RawFacade[JValue] =
     new MutableFacade[JValue] {
       def jnull() = JNull
       def jfalse() = JBoolean.canonicalFalse

--- a/support/rojoma/src/main/scala/Parser.scala
+++ b/support/rojoma/src/main/scala/Parser.scala
@@ -5,7 +5,7 @@ import scala.collection.mutable
 import com.rojoma.json.ast._
 
 object Parser extends SupportParser[JValue] {
-  implicit val facade: Facade[JValue] =
+  implicit val facade: RawFacade[JValue] =
     new MutableFacade[JValue] {
       def jnull() = JNull
       def jfalse() = JBoolean.canonicalFalse

--- a/support/spray/src/main/scala/Parser.scala
+++ b/support/spray/src/main/scala/Parser.scala
@@ -4,7 +4,7 @@ package support.spray
 import spray.json._
 
 object Parser extends SupportParser[JsValue] {
-  implicit val facade: Facade[JsValue] =
+  implicit val facade: RawFacade[JsValue] =
     new SimpleFacade[JsValue] {
       def jnull() = JsNull
       def jfalse() = JsFalse


### PR DESCRIPTION
Fixes https://github.com/non/jawn/issues/101, allowing someone to perform parsing & validation & data-structure-construction in one pass, and throw exceptions with proper char-offsets (from which we can compute the line/col if necessary) when validation fails. This lets us avoid making an intermediate JSON AST in cases where we just want the final non-AST data structure

This could also be useful in cases where you *do* want to build an AST, but want to do validation on that AST and provide source-level error messages (e.g. `expected object at char index 123, got array` rather than `expected object at foo.bar.baz, got array`)

I split out `RawFacade`/`RawFContext` from `Facade`/`FContext`, where the `Raw*` versions have methods that take the current parse index in addition to whatever is already there.

The Non-`Raw*` versions expose the old API that people can override in the old way, as a compatibility shim. While this breaks binary compatibility, hopefully most (?) code should be source compatible under this change.

This isn't "done" yet, but everything compiles and it's worth seeing whether people think it's mergeable before putting in more effort to get it across the finish line.