### PR TITLE
allow building on Java 9

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,18 +3,18 @@ import ReleaseTransformations._
 lazy val previousJawnVersion = "0.11.1"
 
 lazy val stableCrossVersions =
-  Seq("2.10.6", "2.11.12", "2.12.5")
+  Seq("2.10.7", "2.11.12", "2.12.6")
 
 // we'll support 2.13.0-M1 soon but not yet
 lazy val allCrossVersions =
   stableCrossVersions :+ "2.13.0-M3"
 
 lazy val benchmarkVersion =
-  "2.12.5"
+  "2.12.6"
 
 lazy val jawnSettings = Seq(
   organization := "org.spire-math",
-  scalaVersion := "2.12.5",
+  scalaVersion := "2.12.6",
 
   //crossScalaVersions := allCrossVersions,
   crossScalaVersions := stableCrossVersions,

--- a/parser/src/main/scala/jawn/AsyncParser.scala
+++ b/parser/src/main/scala/jawn/AsyncParser.scala
@@ -79,7 +79,7 @@ final class AsyncParser[J] protected[jawn] (
 
   final def absorb(buf: ByteBuffer)(implicit facade: RawFacade[J]): Either[ParseException, Seq[J]] = {
     done = false
-    val buflen = buf.limit - buf.position
+    val buflen = buf.limit() - buf.position()
     val need = len + buflen
     resizeIfNecessary(need)
     buf.get(data, len, buflen)

--- a/parser/src/main/scala/jawn/ByteBufferParser.scala
+++ b/parser/src/main/scala/jawn/ByteBufferParser.scala
@@ -14,8 +14,8 @@ import java.nio.ByteBuffer
  * update its own mutable position fields.
  */
 final class ByteBufferParser[J](src: ByteBuffer) extends SyncParser[J] with ByteBasedParser[J] {
-  private[this] final val start = src.position
-  private[this] final val limit = src.limit - start
+  private[this] final val start = src.position()
+  private[this] final val limit = src.limit() - start
 
   private[this] var lineState = 0
   protected[this] def line(): Int = lineState

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.17


### PR DESCRIPTION
this isn't essential to support, but it's easy to achieve and it will
help us test Scala on Java 9 (via the Scala 2.12 community build)

the Scala and sbt version bumps are necessary for Java 9 friendliness

the (trivial) code changes are because Java stdlib added some new
overloads