### PR TITLE
json4s-3.6.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -150,7 +150,7 @@ lazy val supportArgonaut = support("argonaut")
 lazy val supportJson4s = support("json4s")
   .dependsOn(util)
   .settings(crossScalaVersions := allCrossVersions)
-  .settings(libraryDependencies += "org.json4s" %% "json4s-ast" % "3.5.4")
+  .settings(libraryDependencies += "org.json4s" %% "json4s-ast" % "3.6.0")
 
 lazy val supportPlay = support("play")
   .settings(crossScalaVersions := stableCrossVersions)


### PR DESCRIPTION
json4s-ast-3.6.0 breaks binary compatibility in two places:
* [Remove deprecated JValue#toOpt](https://github.com/json4s/json4s/compare/v3.5.4...v3.6.0#diff-087634be2508f91a1ffd84d9d5c6559eL99)
* [Change Traversable to Iterable in implicit we don't use](https://github.com/json4s/json4s/compare/v3.5.4...v3.6.0#diff-4fe1b09c6cbf1e171550cfbf431c036aR70)

So I think the current version of jawn supports json4s-3.5 and 3.6, but maybe this eases some eviction warnings in the next jawn release.